### PR TITLE
Fix ApiService name and building with Gulp

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,7 +40,6 @@ gulp.task('build', [
 
 // Bundle everything
 gulp.task('build:bundle', [
-    'build:lint',
     'build:app',
     'build:vendor',
     'build:productive-vendor',
@@ -63,7 +62,7 @@ gulp.task('build:bundle', [
 });
 
 // Build app
-gulp.task('build:app', [], function()
+gulp.task('build:app', ['build:lint'], function()
 {
     var builder = browserify({
         entries  : glob.sync("app/!(services)/**/*.js", {cwd: JS_SRC}),

--- a/resources/js/src/app/components/myAccount/AccountSettings.js
+++ b/resources/js/src/app/components/myAccount/AccountSettings.js
@@ -1,5 +1,5 @@
 var ModalService        = require("services/ModalService");
-var APIService          = require("services/APIService");
+var APIService          = require("services/ApiService");
 var NotificationService = require("services/NotificationService");
 
 Vue.component("account-settings", {


### PR DESCRIPTION
Fixed ApiService name.
There are severals problems after building static files with gulp!
After building on this brunch file /plugin-ceres/resources/js/src/app/filters/itemImages.filter.js is not included to buildfiles, thats cuase errors in browser console: http://joxi.ru/EA4XXBWSwjbp4A

Please, fix building files!

UPD: Added fix for building APP after ESLint finishes, that do the trick!