### PR TITLE
Make itemUrl.filter configurable

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,6 +6,13 @@
         "type"      : "category_select"
     },
     {
+        "tab"       : "Global",
+        "key"       : "global.enableOldUrlPattern",
+        "label"     : "Enable Callisto route pattern for articles",
+        "type"      : "checkbox",
+        "default"   : "false"
+    },
+    {
         "tab"       : "Homepage",
         "key"       : "default.homepage",
         "label"     : "Show default homepage",

--- a/config.json
+++ b/config.json
@@ -8,7 +8,7 @@
     {
         "tab"       : "Global",
         "key"       : "global.enableOldUrlPattern",
-        "label"     : "Enable Callisto route pattern for articles",
+        "label"     : "Enable Callisto route pattern for items",
         "type"      : "checkbox",
         "default"   : "false"
     },

--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -5,6 +5,7 @@
 ### Hinzugefügt
 
 - Für die Seitennavigation und die Navigation oben wurde Caching implementiert.
+- Es wurde ein neuer Wert in die Konfiguration hinzugefügt, damit Artikel URLs wie in Callisto aufgebaut sind.
 
 ### Geändert
 

--- a/resources/js/src/app/filters/itemUrl.filter.js
+++ b/resources/js/src/app/filters/itemUrl.filter.js
@@ -5,22 +5,17 @@ Vue.filter("itemURL", function(item)
 
     let link = "/";
 
-    if (urlPath && urlPath.length > 0)
+    if (urlPath && urlPath.length)
     {
         link += urlPath;
+
+        link += enableOldUrlPattern ? "/" : "_";
     }
 
     if (enableOldUrlPattern)
     {
-        return link + "/a-" + item.item.id;
+        return link + "a-" + item.item.id;
     }
 
-    else if (link === "/")
-    {
-        return link + item.item.id + "_" + item.variation.id;
-    }
-    else
-    {
-        return link + "_" + item.item.id + "_" + item.variation.id;
-    }
+    return link + item.item.id + "_" + item.variation.id;
 });

--- a/resources/js/src/app/filters/itemUrl.filter.js
+++ b/resources/js/src/app/filters/itemUrl.filter.js
@@ -1,11 +1,26 @@
 Vue.filter("itemURL", function(item)
 {
-    var urlPath = item.texts.urlPath;
+    const enableOldUrlPattern = App.config.enableOldUrlPattern === "true";
+    const urlPath = item.texts.urlPath;
+
+    let link = "/";
 
     if (urlPath && urlPath.length > 0)
     {
-        return "/" + urlPath + "_" + item.item.id + "_" + item.variation.id;
+        link += urlPath;
     }
 
-    return "/" + item.item.id + "_" + item.variation.id;
+    if (enableOldUrlPattern)
+    {
+        return link + "/a-" + item.item.id;
+    }
+
+    else if (link === "/")
+    {
+        return link + item.item.id + "_" + item.variation.id;
+    }
+    else
+    {
+        return link + "_" + item.item.id + "_" + item.variation.id;
+    }
 });

--- a/resources/views/PageDesign/Partials/Head.twig
+++ b/resources/views/PageDesign/Partials/Head.twig
@@ -44,7 +44,8 @@
             enabledBillingAddressFields: "{{ config("Ceres.billing_address.show") }}",
             enabledBillingAddressFieldsUK: "{{ config("Ceres.billing_address.en.show") }}",
             enabledDeliveryAddressFields: "{{ config("Ceres.delivery_address.show") }}",
-            enabledDeliveryAddressFieldsUK: "{{ config("Ceres.delivery_address.en.show") }}"
+            enabledDeliveryAddressFieldsUK: "{{ config("Ceres.delivery_address.en.show") }}",
+            enableOldUrlPattern: "{{ config("Ceres.global.enableOldUrlPattern") }}"
         },
         isCategoryView: {% if services.template.isCategory() == "1" %}true{% else %}false{% endif %},
         isCheckoutView : {% if services.template.isCheckout() == "1" %}true{% else %}false{% endif %},


### PR DESCRIPTION
ADD enableOldUrlPattern to HEAD.twig (got by config)
CHANGE itemUrl.filter.js - the filter will now check the config value “enableOldUrlPattern”. Belong to this, the url is build up in a different logic.