### PR TITLE
FIX condition in Single Item View and fixed several other issues

### DIFF
--- a/resources/views/Item/Components/SingleItem.twig
+++ b/resources/views/Item/Components/SingleItem.twig
@@ -166,13 +166,12 @@
                                         </tr>
                                     {% endif %}
 
-                                    {# Condition #}
-                                    {#{% if 'item.condition' in itemData or 'all' in itemData %}#}
-                                        {#<tr>#}
-                                            {#<td>{{ trans("Ceres::Template.itemCondition") }}</td>#}
-                                            {#<td>{{ trans("Ceres::Template.itemNew") }}</td>#}
-                                        {#</tr>#}
-                                    {#{% endif %}#}
+                                    {% if 'item.condition' in itemData or 'all' in itemData %}
+                                        <tr>
+                                            <td>{{ trans("Ceres::Template.itemCondition") }}</td>
+                                            <td>${ currentVariation.item.condition.names.name }</td>
+                                        </tr>
+                                    {% endif %}
 
                                     {% if 'item.age_rating' in itemData or 'all' in itemData %}
                                         <tr>
@@ -198,7 +197,7 @@
                                     {% if 'item.manufacturer' in itemData or 'all' in itemData %}
                                         <tr v-if="currentVariation.item.manufacturer.externalName != ''">
                                             <td>{{ trans("Ceres::Template.itemManufacturer") }}</td>
-                                            <td>${ currentVariation.item.manufacturer.externalName }}</td>
+                                            <td>${ currentVariation.item.manufacturer.externalName }</td>
                                         </tr>
                                     {% endif %}
 
@@ -212,21 +211,21 @@
                                     {% if 'item.variationBase_content' in itemData or 'all' in itemData %}
                                         <tr>
                                             <td>{{ trans("Ceres::Template.itemContent") }}</td>
-                                            <td>{{ item.documents[0].data.unit.content|formatDecimal(0) }} ${ currentVariation.unit.names.name }</td>
+                                            <td>${ currentVariation.unit.content|formatDecimal(0) } ${ currentVariation.unit.names.name }</td>
                                         </tr>
                                     {% endif %}
 
                                     {% if 'item.weightG' in itemData or 'all' in itemData %}
                                         <tr v-if="currentVariation.variation.weightG != ''">
                                             <td>{{ trans("Ceres::Template.itemWeight") }}</td>
-                                            <td>${ currentVariation.variation.weightG }g</td>
+                                            <td>${ currentVariation.variation.weightG } g</td>
                                         </tr>
                                     {% endif %}
 
                                     {% if 'item.weightNetG' in itemData or 'all' in itemData %}
                                         <tr v-if="currentVariation.variation.weightNetG != ''">
                                             <td>{{ trans("Ceres::Template.itemNetWeight") }}</td>
-                                            <td>${ currentVariation.variation.weightNetG }g</td>
+                                            <td>${ currentVariation.variation.weightNetG } g</td>
                                         </tr>
                                     {% endif %}
 
@@ -244,7 +243,7 @@
                                     {% if ('item.customs_tariff_number' in itemData or 'all' in itemData) %}
                                         <tr v-if="currentVariation.item.customsTariffNumber != ''">
                                             <td>{{ trans("Ceres::Template.itemCustomsTariffNumber") }}</td>
-                                            <td>${ currentVariation.item.customsTariffNumber }}</td>
+                                            <td>${ currentVariation.item.customsTariffNumber }</td>
                                         </tr>
                                     {% endif %}
                                     </tbody>

--- a/resources/views/Item/SingleItem.fields.json
+++ b/resources/views/Item/SingleItem.fields.json
@@ -11,6 +11,7 @@
   "item.customsTariffNumber",
   "item.producingCountry.names.*",
   "item.storeSpecial",
+  "item.condition.names.*",
 
   "variation.id",
   "variation.name",


### PR DESCRIPTION
With this fix, the condition of the item can now be displayed in the **More details** tab of an item.

<img width="718" alt="bildschirmfoto 2017-11-21 um 17 36 12" src="https://user-images.githubusercontent.com/15801709/33084536-8d8d8678-cee2-11e7-81d2-9a178893174a.png">

The condition changes according to the Setting in the plentymarkets back end.

Several minor styling issues were also fixed.