### PR TITLE
Reduce the links to SingleItem from CategoryItem

### DIFF
--- a/resources/scss/ceres/mixins/_general-mixins.scss
+++ b/resources/scss/ceres/mixins/_general-mixins.scss
@@ -206,7 +206,7 @@
                 & .owl-item {
                     height: 100%;
 
-                    &>a>img{
+                    & img{
                         position: absolute;
                         top: -9999px;
                         right: -9999px;

--- a/resources/views/Category/Item/Partials/CategoryListItem.twig
+++ b/resources/views/Category/Item/Partials/CategoryListItem.twig
@@ -92,18 +92,16 @@
 
                 <div class="prices">
                     {% if item.data.calculatedPrices.rrp.price != '0' %}
-                        <a href="{{ itemUrl }}" class="price-view-port">
+                        <div class="price-view-port">
                             <del class="crossprice">
                                 {{ item.data.calculatedPrices.formatted.rrpUnitPrice }}
                             </del>
-                        </a>
+                        </div>
                     {% endif %}
 
-                    <a href="{{ itemUrl }}">
-                        <div class="price">
-                            {{ item.data.calculatedPrices.formatted.defaultUnitPrice }} *
-                        </div>
-                    </a>
+                    <div class="price">
+                        {{ item.data.calculatedPrices.formatted.defaultUnitPrice }} *
+                    </div>
                 </div>
 
                 {{ LayoutContainer.show("Ceres::CategoryItem.AfterPrices", item.data) }}

--- a/resources/views/ItemList/Components/CategoryImageCarousel.twig
+++ b/resources/views/ItemList/Components/CategoryImageCarousel.twig
@@ -1,18 +1,17 @@
 {{ component( "Ceres::ItemList.Components.ItemLazyImg" ) }}
 
 <script type="x/template" id="vue-category-image-carousel">
-    <div :id="'owl-carousel-' + _uid" v-if="$_enableCarousel" class="owl-carousel owl-theme">
-        <a v-for="(imageUrl, index) in imageUrls" :href="itemUrl">
-
+    <a :id="'owl-carousel-' + _uid" v-if="$_enableCarousel" class="owl-carousel owl-theme" :href="itemUrl">
+        <div v-for="(imageUrl, index) in imageUrls">
             <item-lazy-img template="#vue-item-lazy-img" v-if="index === 0 && !disableLazyLoad" :image-url="imageUrl.url"
                         :alt="altText"></item-lazy-img>
 
-            <img v-if="index !== 0 && !disableLazyLoad" class="img-fluid owl-lazy" :data-src="imageUrl.url" :alt="altText">
+            <img v-else-if="index !== 0 && !disableLazyLoad" class="img-fluid owl-lazy" :data-src="imageUrl.url" :alt="altText">
 
             <img v-else class="img-fluid" :src="imageUrl.url" :alt="altText">
 
-        </a>
-    </div>
+        </div>
+    </a>
 
     <a v-else :href="itemUrl">
         <item-lazy-img v-if="!disableLazyLoad" template="#vue-item-lazy-img" :image-url="imageUrls | itemImage" :alt="altText"></item-lazy-img>

--- a/resources/views/ItemList/Components/CategoryItem.twig
+++ b/resources/views/ItemList/Components/CategoryItem.twig
@@ -51,17 +51,15 @@
                 </a>
                 <div class="thumb-meta">
                     <div class="prices">
-                        <a :href="itemData | itemURL" v-if="recommendedRetailPrice > 0" class="price-view-port">
+                        <div v-if="recommendedRetailPrice > 0" class="price-view-port">
                             <del class="crossprice">
                                 ${ itemData.calculatedPrices.formatted.rrpUnitPrice }
                             </del>
-                        </a>
+                        </div>
 
-                        <a :href="itemData | itemURL">
-                            <div class="price">
-                                ${ itemData.calculatedPrices.formatted.defaultUnitPrice } *
-                            </div>
-                        </a>
+                        <div class="price">
+                            ${ itemData.calculatedPrices.formatted.defaultUnitPrice } *
+                        </div>
                     </div>
 
                     <div class="category-unit-price" v-if="!(itemData.unit.unitOfMeasurement === 'C62' && itemData.unit.content === 1)">


### PR DESCRIPTION
CHANGE CategoryImageCarousel - the image carousel will now not longer create <a> tags for every picture, instead one for the whole carousel

CHANGE CategouryItem / CategoryListItem - remove <a> tags for prices

CHANGE _general-mixins.scss - change the selector chain for images in owl carousel: remove <a> tag from the chain