### PR TITLE
FIX Breadcrumbs

### DIFF
--- a/resources/views/PageDesign/Partials/Header/Breadcrumb.twig
+++ b/resources/views/PageDesign/Partials/Header/Breadcrumb.twig
@@ -11,17 +11,22 @@
                     <i class="fa fa-home" aria-hidden="true"></i>
                 </a>
             </li>
-            {% for category in categoryBreadcrumbs %}
-                {% if loop.last %}
-                    {% if category.details is defined %}
-                        <li class="breadcrumb-item active"><span>{{ category.details.first.name }}</span></li>
-                    {% else %}
-                        <li class="breadcrumb-item active"><span>{{ category | itemName(configItemName) }}</span></li>
-                    {% endif %}
-                {% else %}
+
+            {% set break = false %}
+            {% for category in categoryBreadcrumbs[:categoryBreadcrumbs | length - 1] if not break %}
+                {% if category.details[0] %}
                     <li class="breadcrumb-item"><a href="{{ services.category.getURL( category ) }}" v-render-category="{{ category.id }}">{{ category.details.first.name }}</a></li>
+                {% else %}
+                    {% set break = true %}
                 {% endif %}
             {% endfor %}
+
+            {% set lastCategory = categoryBreadcrumbs | last %}
+            {% if lastCategory.details is defined %}
+                <li class="breadcrumb-item active"><span>{{ lastCategory.details.first.name }}</span></li>
+            {% else %}
+                <li class="breadcrumb-item active"><span>{{ lastCategory | itemName(configItemName) }}</span></li>
+            {% endif %}
         </ul>
     </nav>
 


### PR DESCRIPTION
 If a category is not translated, the breadcrumb chain will be break and display immediately the last item.

### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested

@plentymarkets/ceres-io 