### PR TITLE
FIX SingleItem - the check for variation name will now check for empty, null and undefined

### DIFF
--- a/resources/views/Item/Components/SingleItem.twig
+++ b/resources/views/Item/Components/SingleItem.twig
@@ -22,7 +22,7 @@
                     </div>
 
                     <h1 class="h2 title">
-                        <span v-if="currentVariation.variation.name != ''">
+                        <span v-if="currentVariation.variation.name">
                             ${ currentVariation.variation.name }
                         </span>
 


### PR DESCRIPTION
### All changes meet the following requirements
- [ ] Changelog entry was added
- [x] Changes have been tested

@plentymarkets/ceres-io 