### PR TITLE
FIX remove unused font open sans from font family

### DIFF
--- a/resources/scss/_variables.scss
+++ b/resources/scss/_variables.scss
@@ -137,7 +137,7 @@ $link-hover-color:      darken($link-color, 15%) !default;
 //== Typography
 //
 //## Font, line-height, and color for body text, headings, and more.
-$font-family-sans-serif:'Open Sans', Helvetica, Arial, sans-serif !default;
+$font-family-sans-serif:Helvetica, Arial, sans-serif !default;
 $font-family-helvetica: $font-family-sans-serif !default;
 $font-family-serif:     Georgia, "Times New Roman", Times, serif !default;
 //** Default monospace fonts for `<code>`, `<kbd>`, and `<pre>`.


### PR DESCRIPTION
### All changes meet the following requirements
- [ ] Changelog entry was added
- [x] Changes have been tested

@plentymarkets/ceres-io 