### PR TITLE
FIX Basket.twig

### DIFF
--- a/resources/views/Basket/Basket.twig
+++ b/resources/views/Basket/Basket.twig
@@ -29,7 +29,11 @@
                 </div>
             </div>
 
-            <div class="col-md-5" v-stick-in-parent>
+            <div class="col-md-5">
+                {# this container is required for the v-stick-in-parent directive below #}
+            </div>
+
+            <div class="col-md-5 float-right" v-stick-in-parent>
                 <div class="col-xs-12 p-y-2 bg-white">
                     <hr class="hidden-md-up">
                     <basket-totals class="m-b-2" template="#vue-basket-totals" :config="{{ config("Ceres.basket.data")|split(', ')|json_encode() }}"></basket-totals>


### PR DESCRIPTION
add an empty div container to make the sticky kit work for basket view

### All changes meet the following requirements
- no changelog required
- [x] Changes have been tested

@plentymarkets/ceres-io 