### PR TITLE
FIX shipping-address-select (remove address)

### DIFF
--- a/resources/js/src/app/store/modules/AddressModule.js
+++ b/resources/js/src/app/store/modules/AddressModule.js
@@ -72,7 +72,7 @@ const mutations =
 
                 if (state.deliveryAddress === deliveryAddress)
                 {
-                    state.deliveryAddress = state.deliveryAddress.find(address => address.id === -99);
+                    state.deliveryAddress = state.deliveryAddressList.find(address => address.id === -99);
                     state.deliveryAddressId = -99;
                 }
             }


### PR DESCRIPTION
The selected deliveryAddress will now be removed properly from the list.

### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested

@plentymarkets/ceres-io 