### PR TITLE
FIX QuantityInput - interval 0

### DIFF
--- a/resources/js/src/app/components/item/QuantityInput.js
+++ b/resources/js/src/app/components/item/QuantityInput.js
@@ -61,15 +61,15 @@ Vue.component("quantity-input", {
     {
         this.$options.template = this.template;
 
-        this.compDecimals = floatLength(defaultValue(this.compInterval, 0));
         this.compInterval = defaultValue(this.compInterval, 1);
-        this.onValueChanged = debounce(
-            () =>
-            {
-                this.$emit("quantity-change", this.compValue);
-            },
-            defaultValue(this.timeout, 500)
-        );
+        this.compInterval = this.compInterval === 0 ? 1 : this.compInterval;
+
+        this.compDecimals = floatLength(this.compInterval);
+
+        this.onValueChanged = debounce(() =>
+        {
+            this.$emit("quantity-change", this.compValue);
+        }, defaultValue(this.timeout, 500));
 
         if (!isNullOrUndefined(this.variationId))
         {


### PR DESCRIPTION
If the order interval of an item is 0, the value will be overwritten with 1.

### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 