### PR TITLE
Downgrade owl carousel back to version 2.2.0 (compatibility issues)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4950,8 +4950,8 @@
       }
     },
     "owl.carousel": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/owl.carousel/-/owl.carousel-2.3.3.tgz",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/owl.carousel/-/owl.carousel-2.2.0.tgz",
       "integrity": "sha512-bNIaLcLvpp6jLEp34PzB4VdFjvDGoIs+E5/d+yzDWSFpkPoUEcvAzqBkpsxpcwEcRIKbNvFO9RVdJzKSoiSdAg==",
       "requires": {
         "jquery": "3.3.1"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "jquery": "^3.3.1",
     "lightbox2": "^2.10.0",
     "moment": "^2.22.1",
-    "owl.carousel": "^2.3.3",
+    "owl.carousel": "^2.2.0",
     "popper.js": "^1.14.3",
     "shariff": "^1.24.0",
     "sticky-kit": "^1.1.3",


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 