### PR TITLE
UVP=VKP Patch

### DIFF
--- a/resources/views/Category/Item/Partials/CategoryListItem.twig
+++ b/resources/views/Category/Item/Partials/CategoryListItem.twig
@@ -99,7 +99,7 @@
                 {{ LayoutContainer.show("Ceres::CategoryItem.BeforePrices", item.data) }}
 
                 <div class="prices">
-                    {% if item.data.prices.rrp is defined and item.data.prices.rrp.price.value != 0 %}
+                    {% if item.data.prices.rrp is defined and item.data.prices.rrp.price.value != 0 and item.data.prices.rrp.price.value > item.data.prices.default.unitPrice.value %}
                         <div class="price-view-port">
                             <del class="crossprice">
                                 {{ item.data.prices.rrp.price.formatted }}


### PR DESCRIPTION
Der UVP wird nur noch angezeigt, wenn der VKP kleiner als der UVP ist

### All changes meet the following requirements
- [ ] Changelog entry was added
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 