### PR TITLE
UVP=VKP Patch

### DIFF
--- a/resources/views/ItemList/Components/CategoryItem.twig
+++ b/resources/views/ItemList/Components/CategoryItem.twig
@@ -51,7 +51,7 @@
                 </a>
                 <div class="thumb-meta">
                     <div class="prices">
-                        <div v-if="itemData.prices.rrp && itemData.prices.rrp.price.value > 0" class="price-view-port">
+                        <div v-if="itemData.prices.rrp && itemData.prices.rrp.price.value > 0 && itemData.prices.rrp.price.value > itemData.prices.default.unitPrice.value" class="price-view-port">
                             <del class="crossprice">
                                 ${ itemData.prices.rrp.price.formatted }
                             </del>


### PR DESCRIPTION
Der UVP wird nur noch angezeigt, wenn der VKP kleiner als der UVP ist

### All changes meet the following requirements
- [ ] Changelog entry was added
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 