### PR TITLE
UVP=VKP Patch

### DIFF
--- a/resources/views/Item/Components/SingleItem.twig
+++ b/resources/views/Item/Components/SingleItem.twig
@@ -58,7 +58,7 @@
                     <graduated-prices template="#vue-graduated-prices"></graduated-prices>
 
                     {% if ('item.recommendedPrice' in itemData or 'all' in itemData) %}
-                        <div class="crossprice" v-if="currentVariation.prices.rrp && currentVariation.prices.rrp.price.value > 0">
+                        <div class="crossprice" v-if="currentVariation.prices.rrp && currentVariation.prices.rrp.price.value > 0 && currentVariation.prices.rrp.price.value > currentVariation.prices.default.price.value">
                             <del class="text-muted small">
                                 ${ currentVariation.prices.rrp.price.formatted }
                             </del>


### PR DESCRIPTION
Der UVP wird nur noch angezeigt, wenn der VKP kleiner als der UVP ist

### All changes meet the following requirements
- [ ] Changelog entry was added
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 