### PR TITLE
ADD logic to cut text in variation selects because of styling issues (not clickable) …

### DIFF
--- a/resources/js/src/app/components/item/VariationSelect.js
+++ b/resources/js/src/app/components/item/VariationSelect.js
@@ -1,4 +1,5 @@
 import {isNull}from "util";
+import {textWidth}from "../../helper/dom";
 
 const ApiService = require("services/ApiService");
 
@@ -129,6 +130,16 @@ Vue.component("variation-select", {
             }
 
             return hasChanges;
+        },
+
+        isTextCut(name)
+        {
+            if (this.$refs.labelBoxRef)
+            {
+                return textWidth(name, "Custom-Font, Helvetica, Arial, sans-serif") > this.$refs.labelBoxRef[0].clientWidth;
+            }
+
+            return false;
         },
 
         onSelectionChange(event)

--- a/resources/js/src/app/helper/dom.js
+++ b/resources/js/src/app/helper/dom.js
@@ -46,3 +46,30 @@ export function is(element, selector)
 
     return element.matches(selector);
 }
+
+/**
+ * Get the width of a specified text depending on the font-family
+ *
+ * @param {string} text
+ * @param {string} fontFamily
+ *
+ * @returns {integer}
+ */
+export function textWidth(text, fontFamily)
+{
+    const tag = document.createElement("div");
+
+    tag.style.position = "absolute";
+    tag.style.left = "-99in";
+    tag.style.whiteSpace = "nowrap";
+    tag.style.font = fontFamily;
+    tag.innerHTML = text;
+
+    document.body.appendChild(tag);
+
+    const result = tag.clientWidth;
+
+    document.body.removeChild(tag);
+
+    return result;
+}

--- a/resources/scss/ceres/forms/_select.scss
+++ b/resources/scss/ceres/forms/_select.scss
@@ -23,3 +23,13 @@
 		text-align-last: left;
 	}
 }
+
+.variation-select {
+
+	& label {
+		text-overflow: ellipsis;
+		overflow: hidden;
+		width: 140px;
+		white-space: nowrap;
+	}
+}

--- a/resources/views/Item/Components/VariationSelect.twig
+++ b/resources/views/Item/Components/VariationSelect.twig
@@ -1,7 +1,7 @@
 <script type="x/template" id="vue-variation-select">
     <div>
-        <div class="col-xs-12 col-md-6 col-lg-4" v-for="(attribute, attributeId) in attributes">
-            <div class="input-unit">
+        <div class="col-xs-12 col-md-6 col-lg-4 variation-select" v-for="(attribute, attributeId) in attributes">
+            <div class="input-unit" ref="labelBoxRef">
                 <select class="custom-select text-gray-dark" v-model="selectedAttributes[attributeId]" @change="onSelectionChange(selectedAttributes[attributeId])">
                         <option :value="null">{{ trans("Ceres::Template.singleItemPleaseSelect") }}</option>
                         <option
@@ -11,7 +11,7 @@
                             ${ attributeValue }
                         </option>
                 </select>
-                <label>${ attribute.name }</label>
+                <label v-tooltip="isTextCut(attribute.name)" data-toggle="tooltip" data-placement="top" :title="attribute.name">${ attribute.name }</label>
             </div>
         </div>
     </div>


### PR DESCRIPTION
…and show tooltip

### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 