### PR TITLE
CHANGE QuantityInput - consider decimal separator

### DIFF
--- a/resources/js/src/app/components/item/QuantityInput.js
+++ b/resources/js/src/app/components/item/QuantityInput.js
@@ -177,6 +177,12 @@ Vue.component("quantity-input", {
 
         setValue(value)
         {
+            // consider the configured decimal seperator (if the input is typed in the input field)
+            if (typeof value === "string")
+            {
+                value = value.replace(App.decimalSeparator || ",", ".");
+            }
+
             value = parseFloat(value);
             if (isNaN(value))
             {


### PR DESCRIPTION
If the user enters a decimal number, the input values decimal separator will be replaced by ".".

### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 