### PR TITLE
FIX SeparatorWidget height in Shop Builder

### DIFF
--- a/resources/scss/ceres/widgets/Helper/_base-widget.scss
+++ b/resources/scss/ceres/widgets/Helper/_base-widget.scss
@@ -116,3 +116,7 @@
         }
     }
 }
+
+.widget-editable-min-height {
+    min-height: 40px;
+}

--- a/resources/views/Widgets/Common/SeparatorWidget.twig
+++ b/resources/views/Widgets/Common/SeparatorWidget.twig
@@ -1,1 +1,3 @@
-<hr class="m-y-2">
+{% if isPreview %}<div class="widget-editable-min-height">{% endif %}
+    <hr class="m-y-2">
+{% if isPreview %}</div>{% endif %}


### PR DESCRIPTION
Add a div.widget-editable-min-height surrounding the hr-tag to make it properly selectable during editing in shop builder.

### All changes meet the following requirements
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 