### PR TITLE
FIX 4 Column Grid - Proportional Widgets

### DIFF
--- a/resources/scss/ceres/widgets/Helper/_base-widget.scss
+++ b/resources/scss/ceres/widgets/Helper/_base-widget.scss
@@ -84,6 +84,11 @@
     {
         padding-bottom: 66.6666%;
     }
+    
+    .widget-grid-1-1-1-1 > .widget-inner .widget.widget-proportional
+    {
+        padding-bottom: 100%;
+    }
 
     .widget-grid-1-2 > .widget-inner:last-child .widget-proportional,
     .widget-grid-2-1 > .widget-inner:first-child .widget-proportional,

--- a/resources/views/Widgets/Grid/FourColumnWidget.twig
+++ b/resources/views/Widgets/Grid/FourColumnWidget.twig
@@ -1,4 +1,4 @@
-<div class="widget widget-grid">
+<div class="widget widget-grid widget-grid-1-1-1-1">
     <div class="widget-inner" data-builder-child-container="first">{{ children.first | raw }}</div>
     <div class="widget-inner" data-builder-child-container="second">{{ children.second | raw }}</div>
     <div class="widget-inner" data-builder-child-container="third">{{ children.third | raw }}</div>


### PR DESCRIPTION
Add class widget-grid-1-1-1-1 to set a padding-bottom to proportional widgets in four column grid.

### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 