### PR TITLE
FIX Last Seen Itemlist max-items

### DIFF
--- a/resources/js/src/app/components/containers/LastSeenItemList.js
+++ b/resources/js/src/app/components/containers/LastSeenItemList.js
@@ -1,9 +1,17 @@
 Vue.component("last-seen-item-list", {
 
-    props: {
-        template: {
+    props:
+    {
+        template:
+        {
             type: String,
             default: "#vue-last-seen-item-list"
+        },
+
+        maxItems:
+        {
+            type: Number,
+            default: App.config.itemLists.lastSeenNumber || 4
         }
     },
 
@@ -18,6 +26,6 @@ Vue.component("last-seen-item-list", {
 
     beforeMount()
     {
-        this.$store.dispatch("getLastSeenItems");
+        this.$store.dispatch("getLastSeenItems", this.maxItems);
     }
 });

--- a/resources/js/src/app/store/modules/LastSeenModule.js
+++ b/resources/js/src/app/store/modules/LastSeenModule.js
@@ -48,13 +48,13 @@ const actions =
             return null;
         },
 
-        getLastSeenItems({commit})
+        getLastSeenItems({commit}, maxItems)
         {
             if (!state.isLastSeenItemsLoading)
             {
                 return new Promise((resolve, reject) =>
                 {
-                    const params = {items: App.config.itemLists.lastSeenNumber};
+                    const params = {items: maxItems || App.config.itemLists.lastSeenNumber};
 
                     commit("setIsLastSeenItemsLoading", true);
 

--- a/resources/views/Widgets/Common/ItemListWidget.twig
+++ b/resources/views/Widgets/Common/ItemListWidget.twig
@@ -27,7 +27,7 @@
     <div class="widget-inner">
         {% if listType == "last_seen" and not isPreview %}
             {# render vue component for last seen items #}
-            <last-seen-item-list max-items="{{ maxItems }}">
+            <last-seen-item-list :max-items="{{ maxItems }}">
                 <div class="widget-caption m-b-1" slot="heading">
                     <h2>{{ Twig.trans("Ceres::Template.itemListLastSeen") }}</h2>
                 </div>

--- a/resources/views/Widgets/Common/ItemListWidget.twig
+++ b/resources/views/Widgets/Common/ItemListWidget.twig
@@ -27,7 +27,7 @@
     <div class="widget-inner">
         {% if listType == "last_seen" and not isPreview %}
             {# render vue component for last seen items #}
-            <last-seen-item-list>
+            <last-seen-item-list max-items="{{ maxItems }}">
                 <div class="widget-caption m-b-1" slot="heading">
                     <h2>{{ Twig.trans("Ceres::Template.itemListLastSeen") }}</h2>
                 </div>


### PR DESCRIPTION
CHANGE ItemListWidget, LastSeenItemList, LastSeenModule - consider max items setting in shop builder's item list.

### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 