### PR TITLE
FIX Default Footer Preset - Store Features Background Color 

### DIFF
--- a/resources/scss/ceres/widgets/Common/_list-widget.scss
+++ b/resources/scss/ceres/widgets/Common/_list-widget.scss
@@ -11,6 +11,7 @@
             margin-bottom: 0;
             padding: 0;
             list-style: none;
+            text-align: center;
         }
     }
 }

--- a/resources/scss/ceres/widgets/Common/_list-widget.scss
+++ b/resources/scss/ceres/widgets/Common/_list-widget.scss
@@ -8,6 +8,7 @@
             width: fit-content;
             margin-left: auto;
             margin-right: auto;
+            margin-bottom: 0;
             padding: 0;
             list-style: none;
         }

--- a/resources/scss/ceres/widgets/Grid/_grid-widget.scss
+++ b/resources/scss/ceres/widgets/Grid/_grid-widget.scss
@@ -8,14 +8,14 @@
         display: flex;
     }
 
-    > .widget-inner
+    .widget-inner
     {
         padding-left: 15px;
         padding-right: 15px;
         flex: 1;
     }
 
-    > .widget-inner-stacked
+    .widget-inner-stacked
     {
         margin-left: -15px;
         margin-right: -15px;

--- a/resources/scss/ceres/widgets/Grid/_grid-widget.scss
+++ b/resources/scss/ceres/widgets/Grid/_grid-widget.scss
@@ -8,20 +8,19 @@
         display: flex;
     }
 
-    .widget-inner
+    > .widget-inner
     {
         padding-left: 15px;
         padding-right: 15px;
         flex: 1;
     }
 
-    .widget-inner-stacked
+    > .widget-inner-stacked
     {
         margin-left: -15px;
         margin-right: -15px;
         display: flex;
         flex-direction: column;
-
     }
 
     @include media-breakpoint-up(md)
@@ -50,24 +49,24 @@
         .widget-inner {
             .widget-list {
                 position: relative;
+                height: 100%;
                 color: $footer-features-color;
                 background-color: $footer-features-bg;
                 margin-left: -15px;
                 margin-right: -15px;
                 padding-left: 15px;
                 padding-right: 15px;
+                box-sizing: content-box;
+                margin-bottom: 0;
             }
 
-            &:first-child {
-                .widget-list {
-                    margin-left: 0;
-                    padding-left: 0;
-                }
-            }
-            &:last-child {
-                .widget-list {
-                    margin-right: 0;
-                    padding-right: 0;
+            @include media-breakpoint-down(sm) {
+                &:not(:last-child) {
+                    .widget-list {
+                        .widget-inner {
+                            padding-bottom: 0;
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
The background color of the store features is now properly rendered.

Fullscreen:
<img width="1201" alt="footer_features_full" src="https://user-images.githubusercontent.com/22615263/45083996-76bb4900-b0fd-11e8-8e4a-5dd49315f7fb.png">

With line break:
<img width="857" alt="footer_features_line_break" src="https://user-images.githubusercontent.com/22615263/45084016-7f138400-b0fd-11e8-9745-149a3c611a28.png">


Mobile:
<img width="370" alt="footer_features_mobile" src="https://user-images.githubusercontent.com/22615263/45083991-73c05880-b0fd-11e8-873d-b93bc4852ad1.png">





### All changes meet the following requirements
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 