### PR TITLE
FIX Footer Store Features width

### DIFF
--- a/resources/scss/ceres/widgets/Grid/_grid-widget.scss
+++ b/resources/scss/ceres/widgets/Grid/_grid-widget.scss
@@ -60,6 +60,20 @@
                 margin-bottom: 0;
             }
 
+            &:first-child {
+                .widget-list {
+                    margin-left: 0;
+                    padding-left: 0;
+                }
+            }
+
+            &:last-child {
+                .widget-list {
+                    margin-right: 0;
+                    padding-right: 0;
+                }
+            }
+
             @include media-breakpoint-down(sm) {
                 &:not(:last-child) {
                     .widget-list {


### PR DESCRIPTION
The footer store features will now be rendered properly.

Before:
<img width="1264" alt="bildschirmfoto 2018-09-11 um 11 22 23" src="https://user-images.githubusercontent.com/22615263/45351229-f0e44580-b5b5-11e8-9587-2bd23957f11f.png">

After:
<img width="1230" alt="bildschirmfoto 2018-09-11 um 11 21 51" src="https://user-images.githubusercontent.com/22615263/45351236-f772bd00-b5b5-11e8-9d45-7e8754cf5284.png">


### All changes meet the following requirements
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 