### PR TITLE
use default value true

### DIFF
--- a/contentWidgets.json
+++ b/contentWidgets.json
@@ -796,7 +796,7 @@
                 "required": true,
                 "label": "Widget.newsletterShowPrivacyPolicyCheckboxLabel",
                 "options": {
-                    "defaultValue": false
+                    "defaultValue": true
                 }
             }
         }

--- a/resources/views/Widgets/Common/NewsletterWidget.json
+++ b/resources/views/Widgets/Common/NewsletterWidget.json
@@ -81,7 +81,7 @@
                 "required": true,
                 "label": "Widget.newsletterShowPrivacyPolicyCheckboxLabel",
                 "options": {
-                    "defaultValue": false
+                    "defaultValue": true
                 }
             }
         }


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 