### PR TITLE
Navigation - add min-height if no categories are listed inside the navigation

### DIFF
--- a/resources/scss/ceres/views/PageDesign/_navigation.scss
+++ b/resources/scss/ceres/views/PageDesign/_navigation.scss
@@ -35,6 +35,8 @@ $menu-font-s-lg  		: 1em;
 $menu-font-f-lg  		: $font-family-serif;
 $menu-li-bg-hover		: $brand-primary;
 $menu-li-color-hover	: $white;
+$menu-li-padding-x      : 1rem;
+$menu-li-padding-y      : 1.3rem;
 // bigmenu
 $menu-big-menu-bg 				: darken($brand-primary,10%);
 $menu-big-menu-li-bg			: transparent;
@@ -108,7 +110,7 @@ body.menu-is-visible {
 		position 	: relative;
 
 		&:empty {
-			min-height: calc(#{ $line-height-base }rem + 1.3rem * 2);
+			min-height: $line-height-base + $menu-li-padding-y * 2;
 		}
 
 		li 	{
@@ -200,7 +202,7 @@ body.menu-is-visible {
 				position: relative;
 				transition: all 300ms;
 				>a {
-					padding: 1.3rem 1rem;
+					padding: $menu-li-padding-y $menu-li-padding-x;
 					width:100%;
 				}
 				>ul {

--- a/resources/scss/ceres/views/PageDesign/_navigation.scss
+++ b/resources/scss/ceres/views/PageDesign/_navigation.scss
@@ -107,6 +107,10 @@ body.menu-is-visible {
 		padding 	: 0;
 		position 	: relative;
 
+		&:empty {
+			min-height: calc(#{ $line-height-base }rem + 1.3rem * 2);
+		}
+
 		li 	{
 			width : 100%;
 			cursor: pointer;


### PR DESCRIPTION
Calculating the height by default line-height + padding around the navigation item * 2

With categories:
<img width="1252" alt="bildschirmfoto 2018-10-29 um 16 18 36" src="https://user-images.githubusercontent.com/22615263/47660253-f2ce8c00-db96-11e8-803b-58068889828c.png">

Empty navigation:
<img width="1215" alt="bildschirmfoto 2018-10-29 um 16 17 37" src="https://user-images.githubusercontent.com/22615263/47660262-f5c97c80-db96-11e8-93ad-3ad30105cec2.png">


### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 