### PR TITLE
move login button extender

### DIFF
--- a/resources/views/Customer/Components/Login.twig
+++ b/resources/views/Customer/Components/Login.twig
@@ -28,9 +28,9 @@
             <div :class="{'modal-footer': modalElement, 'row': !modalElement}">
                 <div class="reset-pwd-direction" :class="{'col-xs-7 col-sm-4': !modalElement}">
                     <a href="javascript:void(0)" @click="showResetPwdView" class="small">{{ trans("Ceres::Template.loginForgotPassword") }}?</a>
-                    {{ LayoutContainer.show("Ceres::LoginOverlay.ExtendOverlayButtons") }}
                 </div>
                 <div :class="{'col-xs-5 col-sm-8 text-sm-right': !modalElement}">
+                    {{ LayoutContainer.show("Ceres::LoginOverlay.ExtendOverlayButtons") }}
                     <button @click.prevent="validateLogin" :disabled="isDisabled" class="btn btn-primary btn-medium" :class="{'btn-right': !modalElement}">
                         <i class="fa fa-user" v-waiting-animation="isDisabled"></i>
                         {{ trans("Ceres::Template.login") }}


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 

Over time this LayoutContainer got moved to a wrong place. It belongs next to the login button and not in the reset password container.

Please also refer to this forum post:
https://forum.plentymarkets.com/t/anleitung-container-doppelt-und-dreifach/518237
https://forum-s3.plentymarkets.com/original/3X/0/c/0cfd07c8def923f67cc2a37f8a0ccccdeddcff3b.jpeg