### PR TITLE
Add new LayoutContainer after the opening body tag

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -64,6 +64,11 @@
             "description"   : "Load scripts, events and other JS related items, e.g. Vue components, after frameworks and scripts have been initialised."
         },
         {
+            "key"           : "PageDesign.AfterOpeningBodyTag",
+            "name"          : "Page Desgin: After opening body tag",
+            "description"   : "Add content after the opening body tag."
+        },
+        {
             "key"           : "StaticPages.CancellationRights",
             "name"          : "Static Pages: Cancellation rights",
             "description"   : "Add additional content on the cancellation rights page."

--- a/plugin.json
+++ b/plugin.json
@@ -65,7 +65,7 @@
         },
         {
             "key"           : "PageDesign.AfterOpeningBodyTag",
-            "name"          : "Page Desgin: After opening body tag",
+            "name"          : "Page Design: After opening body tag",
             "description"   : "Add content after the opening body tag."
         },
         {

--- a/plugin.json
+++ b/plugin.json
@@ -65,8 +65,8 @@
         },
         {
             "key"           : "PageDesign.AfterOpeningBodyTag",
-            "name"          : "Page Design: After opening body tag",
-            "description"   : "Add content after the opening body tag."
+            "name"          : "Page Design: After opening HTML body tag",
+            "description"   : "Add content after the opening HTML body tag."
         },
         {
             "key"           : "StaticPages.CancellationRights",

--- a/resources/views/PageDesign/PageDesign.twig
+++ b/resources/views/PageDesign/PageDesign.twig
@@ -39,6 +39,10 @@
 </head>
 
 <body>
+
+{{ LayoutContainer.show("Ceres::PageDesign.AfterOpeningBodyTag") }}
+
+
 <script>
     if('ontouchstart' in document.documentElement)
     {
@@ -226,7 +230,7 @@
 
 
     (function($) {
-        
+
         var header = document.getElementById('page-header');
         var headerLoaded = false;
         var unfixedElements = [];
@@ -286,7 +290,7 @@
                     });
                 }
             }
-            
+
             $(window).scroll(scrollUnfixedElements);
 
             $(document).on('shopbuilder.after.ready', function()

--- a/resources/views/PageDesign/PageDesign.twig
+++ b/resources/views/PageDesign/PageDesign.twig
@@ -42,7 +42,6 @@
 
 {{ LayoutContainer.show("Ceres::PageDesign.AfterOpeningBodyTag") }}
 
-
 <script>
     if('ontouchstart' in document.documentElement)
     {


### PR DESCRIPTION
### All changes meet the following requirements
- [ ] Changelog entry was added
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 
https://forum.plentymarkets.com/t/wunsch-container-direkt-nach-oeffnendem-body-tag/528225/3