### PR TITLE
BasketListItem.twig - fix rendering condition for the shortDescription of an item

### DIFF
--- a/resources/views/Basket/Components/BasketListItem.twig
+++ b/resources/views/Basket/Components/BasketListItem.twig
@@ -156,7 +156,7 @@
                         {% endif %}
 
                         {% if "basket.item.description_short" in basketDetailsData %}
-                            <p class="my-3" v-if="basketItem.variation.data.texts.description" v-html="basketItem.variation.data.texts.shortDescription"></p>
+                            <p class="my-3" v-if="basketItem.variation.data.texts.shortDescription" v-html="basketItem.variation.data.texts.shortDescription"></p>
                         {% endif %}
                     </div>
 


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 