### PR TITLE
Tab Widget - add defaultValue for the widget, with 2 empty tabs

### DIFF
--- a/resources/views/Widgets/Grid/TabWidget.json
+++ b/resources/views/Widgets/Grid/TabWidget.json
@@ -16,6 +16,16 @@
         "tabs": {
             "type": "vertical",
             "isList": "[1,]",
+            "defaultValue": [
+                {
+                    "title": "Tab 1",
+                    "uuid": "3a0ca715-ff40-4446-8393-07f663ce45a2"
+                },
+                {
+                    "title": "Tab 2",
+                    "uuid": "ac25da98-b0f4-4db3-bc8b-4c5a0fcf3150"
+                }
+            ],
             "options": {
                 "name": "Widget.tabNewTabLabel"
             },


### PR DESCRIPTION
### All changes meet the following requirements
- [ ] Changelog entry was added
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 