### PR TITLE
Fix: Missing img on autocomplete search

### DIFF
--- a/resources/scss/ceres/views/PageDesign/_search-box.scss
+++ b/resources/scss/ceres/views/PageDesign/_search-box.scss
@@ -96,6 +96,7 @@ div:not(.top-bar) {
                 {
                     align-self: center;
                     color: $gray-dark;
+                    max-width: 0;
                 }
 
                 & > .autocomplete-image-container


### PR DESCRIPTION
# Fix:
* Missing img on autocomplete when the text is very long

### All changes meet the following requirements
- [ ] Changelog entry was added
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 