### PR TITLE
FIX missing hyphen for gtc and legalDisclosure translation

### DIFF
--- a/resources/views/Widgets/Footer/LegalInformationWidget.twig
+++ b/resources/views/Widgets/Footer/LegalInformationWidget.twig
@@ -34,7 +34,7 @@
         {% endif %}
 
         {% if configuration.showLegalDisclosure %}
-            <a href="{{ Twig.print('urls.legalDisclosure') }}">{{ Twig.trans("Ceres::Template.footerLegalDisclosure") }}</a>
+            <a href="{{ Twig.print('urls.legalDisclosure') }}">{{ Twig.trans("Ceres::Template.footerLegalDisclosure", {"hyphen": "&shy;"}) }}</a>
         {% endif %}
 
         {% if configuration.showPrivacyPolicy %}
@@ -42,7 +42,7 @@
         {% endif %}
 
         {% if configuration.showGtc %}
-            <a href="{{ Twig.print('urls.gtc') }}">{{ Twig.trans("Ceres::Template.footerGtc") }}</a>
+            <a href="{{ Twig.print('urls.gtc') }}">{{ Twig.trans("Ceres::Template.footerGtc", {"hyphen": "&shy;"}) }}</a>
         {% endif %}
 
         {% if config("Ceres.contact.shop_mail") | length > 0 and config("Ceres.contact.shop_mail") != "your@email.com" %}


### PR DESCRIPTION
# Fix
* hyphen replacement for gtc and legalDisclosure

### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 