### PR TITLE
FIX: Topbar widget RAM crash

### DIFF
--- a/resources/views/Widgets/Header/TopBarWidget.twig
+++ b/resources/views/Widgets/Header/TopBarWidget.twig
@@ -166,9 +166,8 @@
                 </div>
             {% endif %}
 
-            {% if enableCurrencySelect %}
+            {% if enableCurrencySelect and not isPreview %}
                 <div id="currencySelect" class="cmp cmp-currency-select collapse">
-                    {% if not isPreview %}
                     <div class="container-max">
                         <div class="row py-3">
                             <div class="currency-list col-12">
@@ -195,7 +194,6 @@
                             </div>
                         </div>
                     </div>
-                    {% endif %}
                 </div>
             {% endif %}
 
@@ -207,7 +205,7 @@
                     <div id="countrySettings" class="cmp cmp-country-settings collapse">
                         <div class="container-max">
                             <div class="row py-3">
-                                {% if enableLanguageSelect %}
+                                {% if enableLanguageSelect and not isPreview %}
                                     <div class="col-12 {% if enableShippingCountrySelect %}col-lg-6{% else %}col-lg-12{% endif %}">
 
                                         <div class="language-settings">
@@ -215,7 +213,6 @@
                                                 <strong>{{ Twig.print('trans("Ceres::Template.headerSelectLanguage")') }}</strong>
                                                 <hr>
                                             </div>
-                                            {% if not isPreview %}
                                             {{ Twig.set("languageList", Twig.call("services.webstoreConfig.getActiveLanguageList")) }}
                                             {{ Twig.set("languageUrls", Twig.call("services.url.getLanguageURLs")) }}
                                             <ul>
@@ -234,7 +231,6 @@
                                                     </li>
                                                {{ Twig.endfor() }}
                                             </ul>
-                                            {% endif %}
                                         </div>
                                     </div>
                                 {% endif %}

--- a/resources/views/Widgets/Header/TopBarWidget.twig
+++ b/resources/views/Widgets/Header/TopBarWidget.twig
@@ -1,4 +1,5 @@
 {% import "Ceres::Widgets.Helper.TwigBuilder" as Twig %}
+{% import "Ceres::Widgets.Helper.WidgetHelper" as WidgetHelper %}
 
 {% set isFixed                      = widget.settings.isFixed.mobile %}
 {% set enableLogin                  = widget.settings.enableLogin.mobile %}
@@ -167,9 +168,9 @@
 
             {% if enableCurrencySelect %}
                 <div id="currencySelect" class="cmp cmp-currency-select collapse">
+                    {% if not isPreview %}
                     <div class="container-max">
                         <div class="row py-3">
-
                             <div class="currency-list col-12">
                                 <div class="list-title">
                                     <strong>{{ Twig.print('trans("Ceres::Template.headerCurrency")') }}</strong>
@@ -194,6 +195,7 @@
                             </div>
                         </div>
                     </div>
+                    {% endif %}
                 </div>
             {% endif %}
 
@@ -213,7 +215,7 @@
                                                 <strong>{{ Twig.print('trans("Ceres::Template.headerSelectLanguage")') }}</strong>
                                                 <hr>
                                             </div>
-
+                                            {% if not isPreview %}
                                             {{ Twig.set("languageList", Twig.call("services.webstoreConfig.getActiveLanguageList")) }}
                                             {{ Twig.set("languageUrls", Twig.call("services.url.getLanguageURLs")) }}
                                             <ul>
@@ -232,6 +234,7 @@
                                                     </li>
                                                {{ Twig.endfor() }}
                                             </ul>
+                                            {% endif %}
                                         </div>
                                     </div>
                                 {% endif %}


### PR DESCRIPTION
Fix
* Topbar widget settings change creates large request which causes the browser window to crash.

### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 