### PR TITLE
Add preload for css

### DIFF
--- a/resources/views/PageDesign/Partials/Head.twig
+++ b/resources/views/PageDesign/Partials/Head.twig
@@ -4,7 +4,7 @@
 <meta name="generator" content="plentymarkets" />
 
 {% set lang = services.sessionStorage.getLang() %}
-{% set defaultCSS = {{ plugin_path('Ceres') }}~"/css/ceres-legacy.css" %}
+{% set defaultCSS = plugin_path('Ceres') ~"/css/ceres-legacy.css" %}
 
 {% if ceresConfig.global.favicon is empty %}
     {% set favicon = url ~ '/tpl/favicon_' ~ webstoreConfig.webstoreId ~ '.ico' %}

--- a/resources/views/PageDesign/Partials/Head.twig
+++ b/resources/views/PageDesign/Partials/Head.twig
@@ -4,6 +4,7 @@
 <meta name="generator" content="plentymarkets" />
 
 {% set lang = services.sessionStorage.getLang() %}
+{% set defaultCSS = "{{ plugin_path('Ceres') }}/css/ceres-legacy.css" %}
 
 {% if ceresConfig.global.favicon is empty %}
     {% set favicon = url ~ '/tpl/favicon_' ~ webstoreConfig.webstoreId ~ '.ico' %}
@@ -35,7 +36,7 @@
             boldItalic: config('Ceres.custom-font-bold-italic')
         }
     %}
-    
+
     {% if customFont.regular %}
         @font-face {
             font-family: "Custom-Font";
@@ -78,8 +79,9 @@
 {% set performanceLevel = config('Ceres.log.performance.level') %}
 {% set itemName = config('Ceres.item.name') %}
 
+<link rel="preload" as="style" href="{{ defaultCSS }}"
 {% if LayoutContainer.show("Ceres::Template.StyleOverwrite") | trim is empty %}
-    <link data-sass-root="{{ plugin_path('Ceres') }}" data-sass-original="{{ plugin_path('Ceres') }}/css/ceres-legacy.scss" rel="stylesheet" href="{{ plugin_path('Ceres') }}/css/ceres-legacy.css">
+    <link data-sass-root="{{ plugin_path('Ceres') }}" data-sass-original="{{ plugin_path('Ceres') }}/css/ceres-legacy.scss" rel="stylesheet" href="{{ defaultCSS }}">
 {% endif %}
 
 {{ LayoutContainer.show("Ceres::Template.StyleOverwrite") }}

--- a/resources/views/PageDesign/Partials/Head.twig
+++ b/resources/views/PageDesign/Partials/Head.twig
@@ -4,7 +4,7 @@
 <meta name="generator" content="plentymarkets" />
 
 {% set lang = services.sessionStorage.getLang() %}
-{% set defaultCSS = plugin_path('Ceres') ~"/css/ceres-legacy.css" %}
+{% set defaultCSS = plugin_path('Ceres') ~ "/css/ceres-legacy.css" %}
 
 {% if ceresConfig.global.favicon is empty %}
     {% set favicon = url ~ '/tpl/favicon_' ~ webstoreConfig.webstoreId ~ '.ico' %}
@@ -81,8 +81,7 @@
 
 <link rel="preload" as="style" href="{{ defaultCSS }}">
 {% if LayoutContainer.show("Ceres::Template.StyleOverwrite") | trim is empty %}
-    <link data-sass-root="{{ plugin_path('Ceres')
-     }}" data-sass-original="{{ plugin_path('Ceres') }}/css/ceres-legacy.scss" rel="stylesheet" href="{{ defaultCSS }}">
+    <link data-sass-root="{{ plugin_path('Ceres') }}" data-sass-original="{{ plugin_path('Ceres') }}/css/ceres-legacy.scss" rel="stylesheet" href="{{ defaultCSS }}">
 {% endif %}
 
 {{ LayoutContainer.show("Ceres::Template.StyleOverwrite") }}

--- a/resources/views/PageDesign/Partials/Head.twig
+++ b/resources/views/PageDesign/Partials/Head.twig
@@ -79,9 +79,10 @@
 {% set performanceLevel = config('Ceres.log.performance.level') %}
 {% set itemName = config('Ceres.item.name') %}
 
-<link rel="preload" as="style" href="{{ defaultCSS }}"
+<link rel="preload" as="style" href="{{ defaultCSS }}">
 {% if LayoutContainer.show("Ceres::Template.StyleOverwrite") | trim is empty %}
-    <link data-sass-root="{{ plugin_path('Ceres') }}" data-sass-original="{{ plugin_path('Ceres') }}/css/ceres-legacy.scss" rel="stylesheet" href="{{ defaultCSS }}">
+    <link data-sass-root="{{ plugin_path('Ceres')
+     }}" data-sass-original="{{ plugin_path('Ceres') }}/css/ceres-legacy.scss" rel="stylesheet" href="{{ defaultCSS }}">
 {% endif %}
 
 {{ LayoutContainer.show("Ceres::Template.StyleOverwrite") }}

--- a/resources/views/PageDesign/Partials/Head.twig
+++ b/resources/views/PageDesign/Partials/Head.twig
@@ -4,7 +4,7 @@
 <meta name="generator" content="plentymarkets" />
 
 {% set lang = services.sessionStorage.getLang() %}
-{% set defaultCSS = "{{ plugin_path('Ceres') }}/css/ceres-legacy.css" %}
+{% set defaultCSS = {{ plugin_path('Ceres') }}~"/css/ceres-legacy.css" %}
 
 {% if ceresConfig.global.favicon is empty %}
     {% set favicon = url ~ '/tpl/favicon_' ~ webstoreConfig.webstoreId ~ '.ico' %}


### PR DESCRIPTION
### All changes meet the following requirements
- [ ] Changelog entry was added
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 
Added Preload for CSS and make the css easier to exchange.
The preload will improve the performance for Ceres slightly, especially for Google Pagespeed.