### PR TITLE
VariationSelect - items without attributes, but with different units display the variation select now properly

### DIFF
--- a/resources/js/src/app/components/item/SingleItem.js
+++ b/resources/js/src/app/components/item/SingleItem.js
@@ -39,7 +39,8 @@ Vue.component("single-item", {
         ...Vuex.mapState({
             currentVariation: state => state.item.variation.documents[0].data,
             isVariationSelected: state => state.item.isVariationSelected,
-            attributes: state => state.variationSelect.attributes
+            attributes: state => state.variationSelect.attributes,
+            units: state => state.variationSelect.units
         }),
 
         ...Vuex.mapGetters([

--- a/resources/js/src/app/components/item/VariationSelect.js
+++ b/resources/js/src/app/components/item/VariationSelect.js
@@ -18,7 +18,6 @@ Vue.component("variation-select", {
     data()
     {
         return {
-            initialVariationId: null,
             filteredVariationsCache: {}
         };
     },
@@ -313,6 +312,7 @@ Vue.component("variation-select", {
             const uniqueValues = [...new Set(Object.values(attributes))];
             const isEmptyOptionSelected = uniqueValues.length === 1 && isNull(uniqueValues[0]);
 
+            // eslint-disable-next-line complexity
             const filteredVariations = this.variations.filter(variation =>
             {
                 // the selected unit is not matching
@@ -322,7 +322,9 @@ Vue.component("variation-select", {
                 }
 
                 // the variation has no attributes (only checked, if any attribute has a selected value); or the variation has attributes and empty option is selected
-                if ((!isEmptyOptionSelected && !variation.attributes.length) || (isEmptyOptionSelected && variation.attributes.length))
+                // requires more than 0 attributes
+                if (((!isEmptyOptionSelected && !variation.attributes.length) || (isEmptyOptionSelected && variation.attributes.length))
+                    && this.attributes.length > 0)
                 {
                     return false;
                 }

--- a/resources/views/Item/Components/SingleItem/SingleItem_Details.twig
+++ b/resources/views/Item/Components/SingleItem/SingleItem_Details.twig
@@ -22,7 +22,7 @@
 </div>
 
 <!-- Variation -->
-<div class="mb-3" v-if="attributes.length">
+<div class="mb-3" v-if="attributes.length || units.length">
     <variation-select></variation-select>
 </div>
 <!-- /Variation -->

--- a/resources/views/Item/Components/VariationSelect.twig
+++ b/resources/views/Item/Components/VariationSelect.twig
@@ -1,6 +1,6 @@
 <script type="x/template" id="vue-variation-select">
     <div>
-        <div v-if="attributes.length || units.length" class="row">
+        <div v-if="attributes.length || Object.keys(units).length" class="row">
             <div class="col-12 variation-select" v-for="attribute in attributes">
                 <!-- dropdown -->
                 <div class="input-unit" ref="attributesContaner" v-if="attribute.type === 'dropdown'">


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 