### PR TITLE
fix url

### DIFF
--- a/resources/views/PageDesign/Partials/PageMetadata.twig
+++ b/resources/views/PageDesign/Partials/PageMetadata.twig
@@ -46,7 +46,7 @@
 {
     "@context": "http://schema.org",
     "@type": "WebSite",
-    "url": "{{ url | json_encode | raw }}",
+    "url": {{ url | json_encode | raw }},
     "potentialAction":{
         "@type": "SearchAction",
         "target": "{{ services.webstoreConfig.getWebstoreConfig().domainSsl ~ urls.search }}?query={search_term}",
@@ -57,4 +57,3 @@
 </script>
 
 <title>{{ title }}</title>
-


### PR DESCRIPTION
### All changes meet the following requirements
- [ ] Changelog entry was added
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 

Aktuell wird die URL bei den schema.org Daten mit doppelten Anführungszeichen (") ausgegeben. 
Aufgrund von Build Problemen in meinem Test-System konnte ich die Änderung nur mit Ceres nicht testen. Ich habe die gleiche Änderung aber 1zu1 in meinem Theme und dort funktioniert es. 