### PR TITLE
Fixed:  Timer behaviour

### DIFF
--- a/resources/js/src/app/services/ModalService.js
+++ b/resources/js/src/app/services/ModalService.js
@@ -68,8 +68,8 @@ module.exports = (function($)
                 $bsModal.modal("hide");
                 $bsModal.one("hidden.bs.modal", function()
                 {
-                    $bsModal.find('.modal-content').unbind('mouseenter');
-                    $bsModal.find('.modal-content').unbind('mouseleave');
+                    $bsModal.find(".modal-content").unbind("mouseenter");
+                    $bsModal.find(".modal-content").unbind("mouseleave");
                     resolve(self);
                 });
             });
@@ -83,12 +83,12 @@ module.exports = (function($)
         function setTimeout(timeout)
         {
             $bsModal.timeout = timeout;
-            $bsModal.find('.modal-content').mouseenter(() =>
+            $bsModal.find(".modal-content").mouseenter(() =>
             {
                 pauseTimeout();
             });
 
-            $bsModal.find('.modal-content').mouseleave(() =>
+            $bsModal.find(".modal-content").mouseleave(() =>
             {
                 continueTimeout();
             });

--- a/resources/js/src/app/services/ModalService.js
+++ b/resources/js/src/app/services/ModalService.js
@@ -68,6 +68,8 @@ module.exports = (function($)
                 $bsModal.modal("hide");
                 $bsModal.one("hidden.bs.modal", function()
                 {
+                    $bsModal.find('.modal-content').unbind('mouseenter');
+                    $bsModal.find('.modal-content').unbind('mouseleave');
                     resolve(self);
                 });
             });
@@ -81,13 +83,12 @@ module.exports = (function($)
         function setTimeout(timeout)
         {
             $bsModal.timeout = timeout;
-
-            $bsModal.find(".modal-content").mouseover(function()
+            $bsModal.find('.modal-content').mouseenter(() =>
             {
                 pauseTimeout();
             });
 
-            $bsModal.find(".modal-content").mouseout(function()
+            $bsModal.find('.modal-content').mouseleave(() =>
             {
                 continueTimeout();
             });


### PR DESCRIPTION
@plentymarkets/ceres-io 
## Reproduce:
* Open addItemToBasket overlay multiple times
## Fixed
* Timer behaviour.
* Replaced mouseover and out with mouseenter and leave
* Removed event listening for mouse events

### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 