### PR TITLE
MobileNavigation - set the initial category in the created hook, to prevent errors during loading facets (category view)

### DIFF
--- a/resources/js/src/app/components/pageDesign/MobileNavigation.js
+++ b/resources/js/src/app/components/pageDesign/MobileNavigation.js
@@ -61,6 +61,8 @@ Vue.component("mobile-navigation", {
     created()
     {
         this.addEventListener();
+
+        this.$store.commit("setCurrentCategory", this.initialCategory);
     },
 
     methods:


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 