### PR TITLE
FIX coupon input disabled layer in read only checkout

### DIFF
--- a/resources/lang/de/Template.properties
+++ b/resources/lang/de/Template.properties
@@ -177,6 +177,7 @@ couponOnlySingleUsage = "Diesen Gutschein kann nicht für Abo-Artikel eingelöst
 couponOnlySubscription = "Der Gutschein kann nur für Abo-Artikel eingelöst werden."
 couponRedeem = "Einlösen"
 couponRedeemFailure = "Der Gutschein konnte nicht eingelöst werden."
+couponReadonlyInfoText = ""
 couponRedeemSuccess = "Der Gutschein wurde erfolgreich eingelöst."
 couponRemove = "Entfernen"
 couponRemoveFailure = "Der Gutschein konnte nicht entfernt werden."

--- a/resources/lang/en/Template.properties
+++ b/resources/lang/en/Template.properties
@@ -178,6 +178,7 @@ couponOnlySubscription = "The coupon can only be redeemed for subscription items
 couponRedeem = "Redeem coupon"
 couponRedeemFailure = "The coupon could not be redeemed."
 couponRedeemSuccess = "The coupon has been redeemed successfully."
+couponReadonlyInfoText = ""
 couponRemove = "Remove"
 couponRemoveFailure = "The coupon could not be removed."
 couponRemoveSuccess = "The coupon has been removed successfully."

--- a/resources/views/Basket/Components/Coupon.twig
+++ b/resources/views/Basket/Components/Coupon.twig
@@ -1,8 +1,10 @@
+{% set couponReadonlyInfoText = trans("Ceres::Template.couponReadonlyInfoText") %}
+
 <script type="x/template" id="vue-coupon">
     <div class="cmp">
-        {% if checkout.readOnly %}
+        {% if checkout.readOnly and couponReadonlyInfoText | trim is not empty %}
             <p>
-                {{ trans("Ceres::Template.couponReadonlyInfoText") }}
+                {{ couponReadonlyInfoText }}
             </p>
         {% endif %}
         <div :class="{'input-group':true,'component-loading':isCheckoutReadonly,'isLoading':isCheckoutReadonly}">

--- a/resources/views/Basket/Components/Coupon.twig
+++ b/resources/views/Basket/Components/Coupon.twig
@@ -1,8 +1,10 @@
 <script type="x/template" id="vue-coupon">
     <div class="cmp">
-        <p v-if="isCheckoutReadonly">
-            {{ trans("Ceres::Template.couponReadonlyInfoText") }}
-        </p>
+        {% if checkout.readOnly %}
+            <p>
+                {{ trans("Ceres::Template.couponReadonlyInfoText") }}
+            </p>
+        {% endif %}
         <div :class="{'input-group':true,'component-loading':isCheckoutReadonly,'isLoading':isCheckoutReadonly}">
             <input type="text" class="form-control" v-model="couponCode" placeholder="{{ trans("Ceres::Template.couponEnterCoupon") }}" @keyup.enter="redeemCode()" :disabled="disabled || isCheckoutReadonly">
             <span class="input-group-btn">

--- a/resources/views/Basket/Components/Coupon.twig
+++ b/resources/views/Basket/Components/Coupon.twig
@@ -1,6 +1,9 @@
 <script type="x/template" id="vue-coupon">
     <div class="cmp">
-        <div class="input-group">
+        <p v-if="isCheckoutReadonly">
+            {{ trans("Ceres::Template.couponReadonlyInfoText") }}
+        </p>
+        <div :class="{'input-group':true,'component-loading':isCheckoutReadonly,'isLoading':isCheckoutReadonly}">
             <input type="text" class="form-control" v-model="couponCode" placeholder="{{ trans("Ceres::Template.couponEnterCoupon") }}" @keyup.enter="redeemCode()" :disabled="disabled || isCheckoutReadonly">
             <span class="input-group-btn">
                 <button class="btn btn-medium btn-primary btn-appearance" type="button" @click="redeemCode()" :disabled="waiting || isCheckoutReadonly" v-if="!disabled">


### PR DESCRIPTION
ADD translation key for info text for coupon in read only checkout

### All changes meet the following requirements
- [ ] Changelog entry was added
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 