### PR TITLE
Add wizard translations to blacklist for multilingualism

### DIFF
--- a/translation.json
+++ b/translation.json
@@ -139,6 +139,7 @@
     "MultilingualismConfig.properties",
     "Widget.properties",
     "Page.properties",
-    "Config.properties"
+    "Config.properties",
+    "Wizard.properties"
   ]
 }


### PR DESCRIPTION
### All changes meet the following requirements
- [ ] Changelog entry was added
- [ ] Changes have been tested
- [ ] Plugin can be built

@plentymarkets/ceres-io 