### PR TITLE
Add assistant translation to black list for multilingualism

### DIFF
--- a/translation.json
+++ b/translation.json
@@ -139,6 +139,7 @@
     "MultilingualismConfig.properties",
     "Widget.properties",
     "Page.properties",
-    "Config.properties"
+    "Config.properties",
+    "Wizard.properties"
   ]
 }


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 