### PR TITLE
fix issue regarding webstores not linked with plugin sets

### DIFF
--- a/src/Wizard/ShopWizard/Services/ShopWizardService.php
+++ b/src/Wizard/ShopWizard/Services/ShopWizardService.php
@@ -74,7 +74,7 @@ class ShopWizardService
         if (count($webstores)) {
             $pluginRepo = pluginApp(PluginRepositoryContract::class);
             foreach ($webstores as $webstore) {
-                if ($pluginRepo->isActiveInPluginSetByName("Ceres", $webstore['pluginSetId'])) {
+                if (!empty($webstore['pluginSetId']) && $pluginRepo->isActiveInPluginSetByName("Ceres", $webstore['pluginSetId'])) {
                     $key = "webstore_" . $webstore['id'] . "." . "pluginSet_" . $webstore['pluginSetId'];
 
                     $webstoresMapped[$key] = [


### PR DESCRIPTION
### All changes meet the following requirements
- [ ] Changelog entry was added
- [ ] Changes have been tested
- [ ] Plugin can be built

@plentymarkets/ceres-io 