### PR TITLE
VariationSelect - if the unit dropdown is not visible, the boxes will not longer be disabled, if they have different unit as the current selected variation

### DIFF
--- a/resources/js/src/app/components/item/VariationSelect.js
+++ b/resources/js/src/app/components/item/VariationSelect.js
@@ -400,7 +400,10 @@ Vue.component("variation-select", {
             const selectedAttributes = JSON.parse(JSON.stringify(this.selectedAttributes));
 
             selectedAttributes[attributeId] = parseInt(attributeValueId) || null;
-            return !!this.filterVariations(selectedAttributes).length;
+
+            const ignoreUnit = !(Object.keys(this.possibleUnits).length > 1 && this.isContentVisible);
+
+            return !!this.filterVariations(selectedAttributes, null, null, ignoreUnit).length;
         },
 
         /**


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 