### PR TITLE
fix/screen_orientation

### DIFF
--- a/resources/js/src/app/main.js
+++ b/resources/js/src/app/main.js
@@ -3,6 +3,7 @@ const NotificationService = require("./services/NotificationService");
 const AutoFocusService = require("./services/AutoFocusService");
 
 import { MediaQueryHelper } from "./helper/MediaQueryHelper";
+import { debounce } from "./helper/debounce";
 import Vue from "vue";
 
 // Frontend end scripts
@@ -321,15 +322,12 @@ if ( headerParent )
         }
     }
 
-    const QueryHelper = new MediaQueryHelper();
-
-    // When window resize to another breakpoint execute functions
-    QueryHelper.addFunction(function()
+    window.addEventListener("resize", debounce(function()
     {
         calculateBodyOffset();
         getHeaderChildrenHeights();
         scrollHeaderElements();
-    });
+    }, 100));
 
     $(window).scroll(scrollHeaderElements);
 


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io  

Changing the screen orientation can change header heights without triggering an internal breakpoint. Debouncing the resize event achieves the same effect of stopping useless calculations as using the MediaQueryHelper, but without potential constraints on the CSS code.