### PR TITLE
FIX monetary formatter appending padding "0" instead of prepending

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2615,6 +2615,12 @@
       "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
       "dev": true
     },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "dev": true
+    },
     "espree": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "build:widgets": "node tools/collectWidgets.js",
     "prebuild": "npm run build:sass-vendor",
     "postbuild": "npm run build:widgets",
-    "compareTranslations": "node tools/compareTranslations.js"
+    "compareTranslations": "node tools/compareTranslations.js",
+    "test": "npm run test:monetaryFormatter",
+    "test:monetaryFormatter": "node -r esm tools/testMonetaryFormatter.js"
   },
   "browserslist": [
     "> .25%"
@@ -37,6 +39,7 @@
     "eslint": "^6.2.1",
     "eslint-config-google": "^0.13.0",
     "eslint-loader": "^2.2.1",
+    "esm": "^3.2.25",
     "expose-loader": "^0.7.5",
     "glob": "^7.0.3",
     "jquery-lazyload": "^1.9.7",

--- a/resources/js/src/app/helper/MonetaryFormatter.js
+++ b/resources/js/src/app/helper/MonetaryFormatter.js
@@ -112,13 +112,14 @@ const MonetaryFormatter = (function()
 
         const formatDecimals = (value, numberOfDecimals) =>
         {
-            let result =  Math.round(value * Math.pow(10, numberOfDecimals))
+            // FIX: add smallest number next to 0 to value to avoid float conversion errors, eg 0.005 => 0.004999999.
+            let result =  Math.round((value + (1/Number.MAX_SAFE_INTEGER)) * Math.pow(10, numberOfDecimals))
                 .toFixed(0)
                 .substr(-1 * numberOfDecimals, numberOfDecimals);
 
             while (result.length < numberOfDecimals)
             {
-                result = result + "0";
+                result = "0" + result;
             }
 
             return result;

--- a/tools/testMonetaryFormatter.js
+++ b/tools/testMonetaryFormatter.js
@@ -1,0 +1,46 @@
+import MonetaryFormatter from "../resources/js/src/app/helper/MonetaryFormatter.js";
+
+const INPUT = [
+    [0, "0,00"],
+    [1000, "1.000,00"],
+    [0.5, "0,50"],
+    [0.50, "0,50"],
+    [0.05, "0,05"],
+    [1.0050, "1,01"],
+    [1.0049, "1,00"],
+    [1.00499, "1,00"],
+    [1.004999, "1,00"],
+    [1.0099, "1,01"],
+    [18.99, "18,99"],
+    [18.9499, "18,95"],
+    [99.99, "99,99"],
+    [99.9949, "99,99"],
+    [99.9950, "100,00"],
+    [99.9999, "100,00"]
+];
+const CURRENCY = "EUR";
+
+global.App = {
+    currencyPattern: {
+        pattern: "#,##0.00 ¤",
+        separator_thousands: ".",
+        separator_decimal: ","
+    }
+};
+
+const formatter = new MonetaryFormatter();
+let errorCount = 0;
+
+INPUT.forEach(input =>
+{
+    const result   = formatter.format(input[0], CURRENCY);
+    const expected = input[1] + " " + CURRENCY;
+
+    if (result !== expected)
+    {
+        errorCount++;
+        console.error(`Error formatting ${input[0]}: Expected "${expected}" got "${result}"`);
+    }
+});
+
+console.log(`Run ${INPUT.length} tests with ${errorCount} errors.`);


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer
- [x] Plugin can be built

@plentymarkets/ceres-io 