### PR TITLE
ADD pass links to legal information pages to translation

### DIFF
--- a/resources/lang/de/Template.properties
+++ b/resources/lang/de/Template.properties
@@ -189,7 +189,7 @@ cookieBarSave = "Speichern"
 cookieBarBack = "Zurück"
 cookieBarPrivacySettings = "Datenschutzeinstellungen"
 cookieBarMoreSettings = "Weitere Einstellungen"
-cookieBarHintText = "Wir nutzen Cookies auf unserer Website. Einige von diesen sind essenziell, während andere uns helfen, diese Website und Ihre Erfahrung zu verbessern."
+cookieBarHintText = "Wir nutzen Cookies auf unserer Website. Einige von diesen sind essenziell, während andere uns helfen, diese Website und Ihre Erfahrung zu verbessern. Weitere Informationen zu den von uns verwendeten Cookies und Ihren Rechten als Nutzer finden Sie in unserer :policy und unserem :legal."
 ; cookieBar - CookieBar
 ; coupon - Gutschein
 couponAlreadyUsedOrInvalidCouponCode = "Der Gutschein wurde bereits verwendet oder ist ungültig."

--- a/resources/lang/en/Template.properties
+++ b/resources/lang/en/Template.properties
@@ -189,7 +189,7 @@ cookieBarSave = "Save"
 cookieBarBack = "Back"
 cookieBarPrivacySettings = "Privacy settings"
 cookieBarMoreSettings = "Further settings"
-cookieBarHintText = "Our website uses cookies. Some of them are essential, others help us improve this website and your user experience."
+cookieBarHintText = "Our website uses cookies. Some of them are essential, others help us improve this website and your user experience. You can find further information about our use of cookies and your rights as a user in our :policy and our :legal."
 ; cookieBar - CookieBar
 ; coupon - Coupon
 couponAlreadyUsedOrInvalidCouponCode = "The coupon has already been used or is invalid."

--- a/resources/views/PageDesign/Components/CookieBar.twig
+++ b/resources/views/PageDesign/Components/CookieBar.twig
@@ -3,7 +3,25 @@
         <div class="container-max" v-if="isVisible">
             <div class="row py-3" v-show="!isExpanded" :class="classes" :style="styles">
                 <div class="col-12 col-md-8">
-                    <p>{{ trans("Ceres::Template.cookieBarHintText") }}</p>
+                    {% autoescape false %}
+                        {% set gtcContent -%}
+                            <a class="text-appearance" href="{{ urls.gtc }}" target="_blank">{{ trans("Ceres::Template.checkoutGtc") }}</a>
+                        {%- endset %}
+
+                        {% set cancellationContent -%}
+                            <a class="text-appearance" href="{{ urls.cancellationRights }}" target="_blank">{{ trans("Ceres::Template.checkoutCancellationRight", {"hyphen": "&shy;"}) }}</a>
+                        {%- endset %}
+
+                        {% set policyContent -%}
+                            <a class="text-appearance" href="{{ urls.privacyPolicy }}" target="_blank">{{ trans("Ceres::Template.checkoutPrivacyPolicy", {"hyphen": "&shy;"}) }}</a>
+                        {%- endset %}
+
+                        {% set legalDisclosureContent -%}
+                            <a class="text-appearance" href="{{ urls.legalDisclosure }}" target="_blank">{{ trans("Ceres::Template.footerLegalDisclosure") }}</a>
+                        {%- endset %}
+
+                        <p>{{ trans("Ceres::Template.cookieBarHintText", {"gtc": gtcContent, "cancellation": cancellationContent, "policy": policyContent, "legal": legalDisclosureContent}) }}</p>
+                    {% endautoescape %}
 
                     <div>
                         {% for consentGroup in get_consent_groups() if consentGroup.consents | length > 0 %}


### PR DESCRIPTION
### All changes meet the following requirements
- [ ] ~~Changelog entry was added~~
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer
- [x] Plugin can be built

@plentymarkets/ceres-io 

@fmutschler 
Bitte den `cookieBarHintText` nochmal prüfen. Es sind jetzt theoretisch die Variablen `:gtc`, `:cancellation`, `:policy`, oder `:legal` für AGBs, Widerrufsrecht, Datenschutzerklärung oder Impressum verfügbar. Evtl. sollten Datenschutzerklärung und Impressum im Standard enthalten sein.