### PR TITLE
RENAME css class 'widget-...-filter' to 'widget-filter-base'

### DIFF
--- a/resources/scss/ceres/views/Category/_category-list-controls.scss
+++ b/resources/scss/ceres/views/Category/_category-list-controls.scss
@@ -152,7 +152,7 @@
 }
 
 .filter-collapse,
-.widget-attributes-properties-characteristics-filter {
+.widget-filter-base {
     .card {
         background-color: transparent;
         border: 0;

--- a/resources/scss/ceres/widgets/Category/_filter-base-widget.scss
+++ b/resources/scss/ceres/widgets/Category/_filter-base-widget.scss
@@ -1,4 +1,4 @@
-.widget-attributes-properties-characteristics-filter
+.widget-filter-base
 {
     padding: 2rem;
     background-color: $white;
@@ -16,6 +16,6 @@
     }
 }
 
-.widget-toolbar .widget-attributes-properties-characteristics-filter {
+.widget-toolbar .widget-filter-base {
     padding: 0;
 }

--- a/resources/scss/ceres/widgets/_widgets.scss
+++ b/resources/scss/ceres/widgets/_widgets.scss
@@ -1,6 +1,6 @@
 @import "mixins/mixins";
 
-@import "Category/attributes-properties-characteristics-filter-widget";
+@import "Category/filter-base-widget";
 @import "Category/item-grid-widget";
 @import "Category/pagination-widget";
 @import "Category/toolbar-widget";

--- a/resources/views/Widgets/Category/Filter/FilterBaseWidget.twig
+++ b/resources/views/Widgets/Category/Filter/FilterBaseWidget.twig
@@ -12,7 +12,7 @@
 
 {% set appearance      = widget.settings.appearance.mobile | default("none") %}
 
-<div class="widget widget-attributes-properties-characteristics-filter widget-{{ appearance }}{% if customClass | length > 0 %} {{ customClass }}{% endif %}{% if spacingMargin | length > 0 %} {{ spacingMargin }}{% endif %}"
+<div class="widget widget-filter-base widget-{{ appearance }}{% if customClass | length > 0 %} {{ customClass }}{% endif %}{% if spacingMargin | length > 0 %} {{ spacingMargin }}{% endif %}"
     {% if inlineMargin | length > 0 %} style="{{ inlineMargin }}"{% endif %}>
 
     <item-filter-list


### PR DESCRIPTION
is required for https://github.com/plentymarkets/feedback-plugin/pull/68

- ~Changelog entry was added~
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer
- [x] Plugin can be built

@plentymarkets/ceres-io 