### PR TITLE
Fix: Liveshopping duration counter days are ceiled to 30 days max

### DIFF
--- a/resources/js/src/app/components/liveShopping/LiveShoppingDetails.js
+++ b/resources/js/src/app/components/liveShopping/LiveShoppingDetails.js
@@ -154,8 +154,9 @@ Vue.component("live-shopping-details", {
         {
             const duration = moment.duration(seconds, "seconds");
 
+            this.realduration = duration;
             return {
-                days: Math.round(duration.asDays()),
+                days: Math.floor(duration.asDays()),
                 hours: duration.hours(),
                 minutes: duration.minutes(),
                 seconds: duration.seconds()

--- a/resources/js/src/app/components/liveShopping/LiveShoppingDetails.js
+++ b/resources/js/src/app/components/liveShopping/LiveShoppingDetails.js
@@ -155,7 +155,7 @@ Vue.component("live-shopping-details", {
             const duration = moment.duration(seconds, "seconds");
 
             return {
-                days: duration.days(),
+                days: Math.round(duration.asDays()),
                 hours: duration.hours(),
                 minutes: duration.minutes(),
                 seconds: duration.seconds()

--- a/resources/js/src/app/components/liveShopping/LiveShoppingDetails.js
+++ b/resources/js/src/app/components/liveShopping/LiveShoppingDetails.js
@@ -153,7 +153,6 @@ Vue.component("live-shopping-details", {
         getDuration(seconds)
         {
             const duration = moment.duration(seconds, "seconds");
-            
             return {
                 days: Math.floor(duration.asDays()),
                 hours: duration.hours(),

--- a/resources/js/src/app/components/liveShopping/LiveShoppingDetails.js
+++ b/resources/js/src/app/components/liveShopping/LiveShoppingDetails.js
@@ -153,8 +153,7 @@ Vue.component("live-shopping-details", {
         getDuration(seconds)
         {
             const duration = moment.duration(seconds, "seconds");
-
-            this.realduration = duration;
+            
             return {
                 days: Math.floor(duration.asDays()),
                 hours: duration.hours(),


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer
- [x] Plugin can be built

@plentymarkets/ceres-io 

Durations longer than 1 month are incorrectly shown, as the moment-duration is read incorrectly.