### PR TITLE
Fix: LiveShopping beenden, wenn Netto-Warenbestand leer ist und darauf limitiert

### DIFF
--- a/resources/js/src/app/components/liveShopping/LiveShoppingDetails.js
+++ b/resources/js/src/app/components/liveShopping/LiveShoppingDetails.js
@@ -92,9 +92,23 @@ Vue.component("live-shopping-details", {
         setQuantitySoldPercentage()
         {
             const data            = this.liveShoppingData.liveShopping;
-            const percentage      = 100 - data.quantitySold / data.quantityMax * 100;
+            const item            = this.liveShoppingData.item;
 
-            this.itemQuantityRemaining = data.quantityMax - data.quantitySold;
+            let percentage = 0;
+
+            const isStockLimited = item.stock.net < data.quantityMax - data.quantitySold;
+
+            if (item.variation.stockLimitation === 1 && isStockLimited)
+            {
+                percentage = (data.quantityMax - item.stock.net) / data.quantityMax * 100;
+                this.itemQuantityRemaining = item.stock.net;
+            }
+            else
+            {
+                percentage = 100 - data.quantitySold / data.quantityMax * 100;
+                this.itemQuantityRemaining = data.quantityMax - data.quantitySold;
+            }
+
             this.quantitySoldPercentage = percentage.toFixed(App.config.item.storeSpecial);
         },
 

--- a/resources/js/src/app/components/liveShopping/LiveShoppingItem.js
+++ b/resources/js/src/app/components/liveShopping/LiveShoppingItem.js
@@ -69,6 +69,12 @@ Vue.component("live-shopping-item", {
             if (!isNullOrUndefined(this.currentOffer))
             {
                 const liveShopping = this.currentOffer.liveShopping;
+                const item = this.currentOffer.item;
+
+                if (item.variation.stockLimitation === 1)
+                {
+                    return item.stock.net > 0;
+                }
 
                 return liveShopping.quantitySold < liveShopping.quantityMax;
             }


### PR DESCRIPTION
### All changes meet the following requirements
- [ ] Changelog entry was added
- [x] Changes have been tested by the author
- [ ] Changes have been tested by the reviewer
- [x] Plugin can be built

@plentymarkets/ceres-io 