### PR TITLE
FIX add has_component_template check to include_components

### DIFF
--- a/resources/views/PageDesign/Macros/IncludeComponents.twig
+++ b/resources/views/PageDesign/Macros/IncludeComponents.twig
@@ -1,5 +1,7 @@
 {% macro include_components() %}
-    {% include get_component_template() ignore missing %}
+    {% if has_component_template() %}
+        {% include get_component_template() ignore missing %}
+    {% endif %}
 
     {% if has_component_template() %}
         {{ _self.include_components() }}

--- a/resources/views/PageDesign/Macros/IncludeComponents.twig
+++ b/resources/views/PageDesign/Macros/IncludeComponents.twig
@@ -1,9 +1,6 @@
 {% macro include_components() %}
     {% if has_component_template() %}
         {% include get_component_template() ignore missing %}
-    {% endif %}
-
-    {% if has_component_template() %}
         {{ _self.include_components() }}
     {% endif %}
 {% endmacro %}


### PR DESCRIPTION
When no component templates are registered, include_components is still executed.
Without a check for component templates, this fails.

### FOR TESTING PURPOSES
#### fix/missing_has_component_check_test
This branch has all {{ component() }} and {{ Twig.component() }} calls removed.
Add and remove a has_component_template() call in IncludeComponents.twig around the get_component_template call to test the fix.


### All changes meet the following requirements
- [ ] Changelog entry was added
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer
- [x] Plugin can be built

@plentymarkets/ceres-io 