### PR TITLE
FIX NavigationTree - the active category will now be opened on load

### DIFF
--- a/resources/views/Category/Macros/CategoryTree.twig
+++ b/resources/views/Category/Macros/CategoryTree.twig
@@ -133,7 +133,7 @@
         {% endfor %}
 
         <ul>
-            <li class="nav-item{% if isCategoryActive %} active{% endif %}">
+            <li class="nav-item{% if isCategoryActive %} active is-open{% endif %}">
                 {% if category.children is not empty and expandableChildren %}
                     <div v-sidenavigation-children="{ 
                             categoryId: {{ category.id }}, 
@@ -145,7 +145,6 @@
                             inlinePadding: {{ inlinePadding | json_encode }} }"
                          class="expand_nav{% if spacingPadding | length > 0 %} {{ spacingPadding }}{% endif %}"
                          {% if inlinePadding | length > 0 %} style="{{ inlinePadding }}"{% endif %}>
-
                         <i class="fa fa-caret-right" aria-hidden="true"></i>
                     </div>
                 {% endif %}

--- a/src/Widgets/Presets/ItemCategoryPreset.php
+++ b/src/Widgets/Presets/ItemCategoryPreset.php
@@ -238,7 +238,9 @@ class ItemCategoryPreset implements ContentPreset
     private function createNavigationTreeWidget()
     {
         $this->twoColumnWidget->createChild('first', 'Ceres::NavigationTreeWidget')
-                              ->withSetting('customClass', '');
+                              ->withSetting('customClass', '')
+                              ->withSetting('expandableChildren', true)
+                              ->withSetting('showItemCount', true);
     }
     
     private function createItemGridWidget()


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested by the author
- [ ] Changes have been tested by the reviewer
- [x] Plugin can be built

@plentymarkets/ceres-io 