### PR TITLE
Feature/beta5/add intersects

### DIFF
--- a/resources/views/Widgets/Common/ItemListWidget.twig
+++ b/resources/views/Widgets/Common/ItemListWidget.twig
@@ -121,7 +121,7 @@
                     </div>
                 {% endif %}
                 {{ Twig.if("#{ listType | json_encode } != 'cross_selling' or services.template.isCurrentTemplate('tpl.item')") }}
-                    <intersect :threshold="0.05">
+                    <intersect>
                         <carousel :items-per-page="{{ itemsPerPage }}">
                             {{ Twig.for("item", "itemList.documents") }}
                                 <template slot="items">

--- a/resources/views/Widgets/Common/ItemListWidget.twig
+++ b/resources/views/Widgets/Common/ItemListWidget.twig
@@ -67,26 +67,36 @@
     <div class="widget-inner">
         {% if listType == "last_seen" and not isPreview %}
             {# render vue component for last seen items #}
-            <last-seen-item-list
-                :items-per-page="{{ itemsPerPage }}"
-                :max-items="{{ maxItems }}"
-                {% if spacingPadding | length > 0 %}padding-classes="{{ spacingPadding }}"{% endif %}
-                {% if inlinePadding | length > 0 %}padding-inline-styles="{{ inlinePadding }}"{% endif %}
-                v-cloak>
-                <template #heading>
-                    <div class="widget-caption bg-appearance widget-item-list-caption mb-3">
-                        {% if headlineStyle == "custom-caption" %}
-                            <div class="widget-item-list-inline-caption" {{ WidgetHelper.makeEditable("headline", TOOLBAR_LAYOUT.INLINE, isPreview, "widget-item-list-inline-caption") }}>
-                                {{ headline | raw }}
-                            </div>
-                        {% else %}
-                            <div>
-                                <h2>{{ Twig.print("title") }}</h2>
-                            </div>
-                        {% endif %}
+            <intersect>
+                <last-seen-item-list
+                    :items-per-page="{{ itemsPerPage }}"
+                    :max-items="{{ maxItems }}"
+                    {% if spacingPadding | length > 0 %}padding-classes="{{ spacingPadding }}"{% endif %}
+                    {% if inlinePadding | length > 0 %}padding-inline-styles="{{ inlinePadding }}"{% endif %}
+                    v-cloak>
+                    <template #heading>
+                        <div class="widget-caption bg-appearance widget-item-list-caption mb-3">
+                            {% if headlineStyle == "custom-caption" %}
+                                <div class="widget-item-list-inline-caption" {{ WidgetHelper.makeEditable("headline", TOOLBAR_LAYOUT.INLINE, isPreview, "widget-item-list-inline-caption") }}>
+                                    {{ headline | raw }}
+                                </div>
+                            {% else %}
+                                <div>
+                                    <h2>{{ Twig.print("title") }}</h2>
+                                </div>
+                            {% endif %}
+                        </div>
+                    </template>
+                </last-seen-item-list>
+                <template #loading>
+                    <div class="category-item-placeholder w-100 invisible">
+                        <a href="#" class="small">
+                            <i class="fa fa-image"></i>
+                            <span></span>
+                        </a>
                     </div>
                 </template>
-            </last-seen-item-list>
+            </intersect>
         {% else %}
             {{ Twig.if("itemList.documents is not empty or #{ isPreview | json_encode }") }}
 
@@ -111,6 +121,7 @@
                     </div>
                 {% endif %}
                 {{ Twig.if("#{ listType | json_encode } != 'cross_selling' or services.template.isCurrentTemplate('tpl.item')") }}
+                    <intersect :threshold="0.05">
                         <carousel :items-per-page="{{ itemsPerPage }}">
                             {{ Twig.for("item", "itemList.documents") }}
                                 <template slot="items">
@@ -135,6 +146,19 @@
                                 </template>
                             {{ Twig.endfor() }}
                         </carousel>
+                        <template #loading>
+                            <div class="row">
+                                {{ Twig.for("item", "itemList.documents") }}
+                                <div class="category-item-placeholder invisible col-12 col-sm-6 col-md-3">
+                                    <a href="{{ Twig.print("item.data | itemURL(buildUrlWithVariationId | json_encode)") }}" class="small">
+                                        <i class="fa fa-image"></i>
+                                        <span>{{ Twig.print("item.data | itemName") }}</span>
+                                    </a>
+                                </div>
+                                {{ Twig.endfor() }}
+                            </div>
+                        </template>
+                    </intersect>
                 {{ Twig.elseif("#{ isPreview | json_encode }") }}
                     <div class="widget-placeholder prop-3-1 proportional-placeholder">
                         <div>

--- a/resources/views/Widgets/Common/LiveShoppingWidget.twig
+++ b/resources/views/Widgets/Common/LiveShoppingWidget.twig
@@ -12,21 +12,31 @@
     {% if inlineMargin | length > 0 %} style="{{ inlineMargin }}"{% endif %}>
     <div class="row clearfix">
         <div class="col-12">
-            <live-shopping-item
-                :live-shopping-id="{{ liveShoppingConfig.liveShoppingSelection }}"
-                :display-settings="{{ liveShoppingConfig | json_encode }}"
-                :show-net-prices="{{ Twig.print("services.customer.showNetPrices() | json_encode") }}"
-                {% if spacingPadding | length > 0 %}padding-classes="{{ spacingPadding }}"{% endif %}
-                {% if inlinePadding | length > 0 %}padding-inline-styles="{{ inlinePadding }}"{% endif %}>
-                {% if isPreview %}
-                    <div class="widget-placeholder prop-2-3 proportional-placeholder">
-                        <div>
-                            <p class="title">{{ Twig.trans("Ceres::Widget.liveShoppingPlaceholderTitle") }}</p>
-                            <p class="description">{{ Twig.trans("Ceres::Widget.liveShoppingPlaceholderDescription") }}</p>
+            <intersect>
+                <live-shopping-item
+                    :live-shopping-id="{{ liveShoppingConfig.liveShoppingSelection }}"
+                    :display-settings="{{ liveShoppingConfig | json_encode }}"
+                    :show-net-prices="{{ Twig.print("services.customer.showNetPrices() | json_encode") }}"
+                    {% if spacingPadding | length > 0 %}padding-classes="{{ spacingPadding }}"{% endif %}
+                    {% if inlinePadding | length > 0 %}padding-inline-styles="{{ inlinePadding }}"{% endif %}>
+                    {% if isPreview %}
+                        <div class="widget-placeholder prop-2-3 proportional-placeholder">
+                            <div>
+                                <p class="title">{{ Twig.trans("Ceres::Widget.liveShoppingPlaceholderTitle") }}</p>
+                                <p class="description">{{ Twig.trans("Ceres::Widget.liveShoppingPlaceholderDescription") }}</p>
+                            </div>
                         </div>
+                    {% endif %}
+                </live-shopping-item>
+                <template #loading>
+                    <div class="category-item-placeholder w-100 invisible">
+                        <a href="#" class="small">
+                            <i class="fa fa-image"></i>
+                            <span></span>
+                        </a>
                     </div>
-                {% endif %}
-            </live-shopping-item>
+                </template>
+            </intersect>
         </div>
     </div>
 </div>

--- a/resources/views/Widgets/Item/AddToBasketWidget.twig
+++ b/resources/views/Widgets/Item/AddToBasketWidget.twig
@@ -23,21 +23,28 @@
 
     {{ Twig.print(Twig.call("LayoutContainer.show", ["Ceres::SingleItem.BeforeAddToBasket", Twig.var("item.documents[0].data")])) }}
 
-    <div class="w-100" v-if="$store.state.item.variation.documents">
+    <intersect>
+        <div class="w-100" v-if="$store.state.item.variation.documents">
 
-        {{ AddToBasket.printVueComponent(
-            "$store.state.item.variation.documents[0].data",
-            false,
-            true,
-            {
-                ":missing-order-properties":"$store.getters.variationMissingProperties",
-                ":has-price": "$store.state.item.variation.documents[0].data | hasItemDefaultPrice",
-                "button-size": buttonSize,
-                "padding-classes": spacingPadding,
-                "padding-inline-styles": inlinePadding
-            }
-        ) }}
-    </div>
+            {{ AddToBasket.printVueComponent(
+                "$store.state.item.variation.documents[0].data",
+                false,
+                true,
+                {
+                    ":missing-order-properties":"$store.getters.variationMissingProperties",
+                    ":has-price": "$store.state.item.variation.documents[0].data | hasItemDefaultPrice",
+                    "button-size": buttonSize,
+                    "padding-classes": spacingPadding,
+                    "padding-inline-styles": inlinePadding
+                }
+            ) }}
+        </div>
+        <template #loading>
+            <div class="w-100 invisible">
+                <button class="btn btn-block"></button>
+            </div>
+        </template>
+    </intersect>
 
     {{ Twig.print(Twig.call("LayoutContainer.show", ["Ceres::SingleItem.AfterAddToBasket", Twig.var("item.documents[0].data")])) }}
 </div>


### PR DESCRIPTION
Add intersect components to certain "expensive" widgets, which are likely to not be instantly on the screen to facilitate a faster clientside startup.

### All changes meet the following requirements
- [ ] Changelog entry was added
- [x] Changes have been tested by the author
- [ ] Changes have been tested by the reviewer
- [ ] Plugin can be built

@plentymarkets/ceres-io 