### PR TITLE
Image carousels - cloned items are now (lazy) load properly

### DIFF
--- a/resources/js/src/app/components/itemList/CategoryImageCarousel.js
+++ b/resources/js/src/app/components/itemList/CategoryImageCarousel.js
@@ -114,10 +114,13 @@ Vue.component("category-image-carousel", {
                 ],
                 onTranslated(event)
                 {
-                    const target = $(event.currentTarget);
-                    const owlItem = $(target.find(".owl-item.active"));
+                    const element = event.target.querySelector(".owl-item.active img");
 
-                    owlItem.find(".img-fluid.lazy").show().lazyload({ threshold : 100 });
+                    if (element && element.dataset.src && !element.src)
+                    {
+                        element.src = element.dataset.src;
+                        element.removeAttribute("data-src");
+                    }
                 },
                 onInitialized: event =>
                 {

--- a/resources/scss/ceres/plugins/_owl-carousel.scss
+++ b/resources/scss/ceres/plugins/_owl-carousel.scss
@@ -72,6 +72,10 @@
   width: 100%;
   object-fit: contain;
   height: 100%;
+
+  &:not([src]) {
+    opacity: 0;
+  }
 }
 
 .owl-carousel .owl-nav.disabled,

--- a/resources/views/Item/Components/ItemImageCarousel.twig
+++ b/resources/views/Item/Components/ItemImageCarousel.twig
@@ -3,7 +3,7 @@
         <div class="single-carousel owl-carousel owl-theme owl-single-item" ref="single">
             <div v-for="image in singleImages" class="prop-xs-1-1">
                 <a :href="image.url" data-lightbox="single-big-image-gallery">
-                    <lazy-img :image-url="image.url" :alt="getAltText(image)" :title="getImageName(image)"></lazy-img>
+                    <img class="owl-lazy" :data-src="image.url" :alt="getAltText(image)" :title="getImageName(image)">
                 </a>
             </div>
         </div>


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer
- [x] Plugin can be built

@plentymarkets/ceres-io 