### PR TITLE
ITEMSETS: Fix TextWidget for itemsets

### DIFF
--- a/resources/views/Widgets/Item/ItemSetWidget.twig
+++ b/resources/views/Widgets/Item/ItemSetWidget.twig
@@ -19,6 +19,8 @@
                 {{ children.itemSet | raw }}
             </div>
         </item-set-component>
+
+        {{ Twig.print(Twig.call("pop_item_data_base")) }}
     {{ Twig.endfor() }}
 
 </div>

--- a/src/Extensions/TwigItemDataField.php
+++ b/src/Extensions/TwigItemDataField.php
@@ -21,7 +21,12 @@ class TwigItemDataField extends Twig_Extension
      */
     private $twig;
 
-    private $itemData = null;
+    /**
+     * @var array $itemData
+     * This array acts as a stack (LIFO)
+     * The last element is used for datafield fetches
+     */
+    private $itemData = [];
 
     /**
      * TwigStyleScriptTagFilter constructor.
@@ -51,6 +56,7 @@ class TwigItemDataField extends Twig_Extension
     {
         return [
             $this->twig->createSimpleFunction('set_item_data_base', [$this, 'setItemDataBase']),
+            $this->twig->createSimpleFunction('pop_item_data_base', [$this, 'popItemDataBase']),
             $this->twig->createSimpleFunction('item_data_field', [$this, 'getDataField'], ['is_safe' => array('html')]),
             $this->twig->createSimpleFunction(
                 'item_data_field_html',
@@ -75,8 +81,14 @@ class TwigItemDataField extends Twig_Extension
 
     public function setItemDataBase($itemData)
     {
-        $this->itemData = $itemData;
-        return "";
+        $this->itemData[] = $itemData;
+        return '';
+    }
+
+    public function popItemDataBase()
+    {
+        array_pop($this->itemData);
+        return '';
     }
 
     /**
@@ -86,7 +98,9 @@ class TwigItemDataField extends Twig_Extension
      */
     public function getDataField($field, $filter = null, $directiveType = "text", $htmlTagType = "span", $linkType = "")
     {
-        $twigPrint = SafeGetter::get($this->itemData, $field);
+        $itemData = end($this->itemData);
+        reset($this->itemData);
+        $twigPrint = SafeGetter::get($itemData, $field);
         if (!is_null($filter)) {
             try {
                 /** @var Twig $twigRenderer */

--- a/src/Extensions/TwigItemDataField.php
+++ b/src/Extensions/TwigItemDataField.php
@@ -98,8 +98,7 @@ class TwigItemDataField extends Twig_Extension
      */
     public function getDataField($field, $filter = null, $directiveType = "text", $htmlTagType = "span", $linkType = "")
     {
-        $itemData = end($this->itemData);
-        reset($this->itemData);
+        $itemData = $this->itemData[count($this->itemData)-1];
         $twigPrint = SafeGetter::get($itemData, $field);
         if (!is_null($filter)) {
             try {


### PR DESCRIPTION
### All changes meet the following requirements
- [ ] Changelog entry was added
- [x] Changes have been tested by the author
- [ ] Changes have been tested by the reviewer
- [ ] Plugin can be built

@plentymarkets/ceres-io 

Durch set_item_data_base wird von Set Widgets die Datenbasis für das SetWidget überschrieben. Dadurch kann es passieren, dass die SingleItem keine Daten mehr bekommt fürd TextWidget. Die Idee hinter diesem PR ist, die Datenstruktur von itemData in einen "Stack" umzubauen, sodass die itemDaten der Set-Komponenten einfach wieder vom Stack runtergenommen werden, nach dem sie nicht mehr gebraucht werden und die SingleItem wieder ihre Daten verwenden kann.