### PR TITLE
FIX OrderHistoryListItem.twig - add missing closing tag

### DIFF
--- a/resources/views/MyAccount/Components/OrderHistoryListItem.twig
+++ b/resources/views/MyAccount/Components/OrderHistoryListItem.twig
@@ -63,6 +63,7 @@
                     <a :href="$ceres.urls.confirmation + '?orderId=' + order.id" target="_blank" rel="noopener" class="btn btn-block btn-primary btn-appearance">
                         <span>{{ trans("Ceres::Template.orderHistoryOrderDetails") }}</span>
                         <i class="fa fa-eye fa-flip-horizontal" aria-hidden="true"></i>
+                    </a>
                     {#
                         <!-- for "order again" in the future -->
                         <a href="" @click.stop class="btn btn-block btn-primary btn-appearance">


### PR DESCRIPTION
### All changes meet the following requirements
- ~Changelog entry was added~
- [x] Changes have been tested by the author
- [ ] Changes have been tested by the reviewer
- [x] Plugin can be built

@plentymarkets/ceres-io 