### PR TITLE
Fix a reference error blocking parallel loading of google maps

### DIFF
--- a/resources/js/src/app/components/common/GoogleMaps.vue
+++ b/resources/js/src/app/components/common/GoogleMaps.vue
@@ -96,7 +96,7 @@ export default {
                 {
                     // script already injected...
                     this.scriptBlocked = false;
-                    if (isNullOrUndefined(google))
+                    if (isNullOrUndefined(window.google))
                     {
                         // ...but not loaded yet
                         script.addEventListener("load", () => resolve(script), false);


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested by the author
- [ ] Changes have been tested by the reviewer

@plentymarkets/ceres-io 

Accessing the variable as an object key avoids a reference error, instead just returning undefined as intended.