### PR TITLE
FIX/proportional classes should overwrite inherited min height from parent

### DIFF
--- a/resources/scss/ceres/widgets/Helper/_base-widget.scss
+++ b/resources/scss/ceres/widgets/Helper/_base-widget.scss
@@ -141,6 +141,7 @@ header .widget {
                 }
                 .widget-proportional.widget-prop#{$infix}-#{$i}-#{$j} {
                     height: auto !important; // stylelint-disable-line declaration-no-important
+                    min-height: auto !important; // stylelint-disable-line declaration-no-important
                     padding-bottom: percentage($j / $i) !important; // stylelint-disable-line declaration-no-important
                 }
             }


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested by the author
- [ ] Changes have been tested by the reviewer

@plentymarkets/ceres-io 