### PR TITLE
ItemSearch - fix autocomplete closing behavior

### DIFF
--- a/resources/js/src/app/components/itemList/ItemSearch.vue
+++ b/resources/js/src/app/components/itemList/ItemSearch.vue
@@ -3,7 +3,7 @@
         <div class="position-relative">
             <div class="d-flex flex-grow-1 position-relative my-2">
                 <input type="search" class="search-input flex-grow-1 px-3 py-2" ref="searchInput" v-model="searchString" @input="onValueChanged($event.target.value)"
-                    @keyup.enter="search()" @focus="isSearchFocused = true" @blur="setIsSearchFocused(false)" :autofocus="isShopBuilder">
+                    @keyup.enter="search()" @focus="isSearchFocused = true" @blur="onBlurSearchField($event)" :autofocus="isShopBuilder">
 
                 <slot name="search-button">
                     <button class="search-submit px-3" type="submit" @click="search()">
@@ -137,13 +137,15 @@ export default {
             }
         },
 
-        // hide autocomplete after 100ms to make clicking on it possible
-        setIsSearchFocused(value)
+        // hide search, if targetElement of the blur event is not a child of components' root element
+        onBlurSearchField(event)
         {
-            setTimeout(() =>
+            const target = event.relatedTarget;
+
+            if (isNullOrUndefined(target) || !isNullOrUndefined(target) && !this.$el.contains(target))
             {
-                this.isSearchFocused = !!value;
-            }, 100);
+                this.isSearchFocused = false;
+            }
         }
     },
 

--- a/resources/js/src/app/components/itemList/SearchSuggestionItem.vue
+++ b/resources/js/src/app/components/itemList/SearchSuggestionItem.vue
@@ -8,7 +8,8 @@
                     :class="paddingClasses"
                     :style="paddingInlineStyles"
                     :key="index"
-                    :href="getTargetUrl(item)">
+                    :href="getTargetUrl(item)"
+                    tabindex="0">
 
                     <div class="image flex-shrink-0 mr-3" v-if="showImages">
                         <img v-if="item.image" :src="item.image">

--- a/resources/scss/ceres/common/_search-box.scss
+++ b/resources/scss/ceres/common/_search-box.scss
@@ -13,6 +13,7 @@
     overflow: hidden;
     white-space: nowrap;
     cursor: pointer;
+    outline: none;
 
     &:hover {
         background: $gray-300;


### PR DESCRIPTION
the search autocomplete-suggestions will now be only closed, if the element is not a child of the component's element

### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer

@plentymarkets/ceres-io 