### PR TITLE
FIX/added workaround for flexbox bug 11 in safari

### DIFF
--- a/resources/scss/ceres/widgets/Grid/_grid-widget.scss
+++ b/resources/scss/ceres/widgets/Grid/_grid-widget.scss
@@ -46,3 +46,7 @@
 html.ie .widget-grid .widget-inner-stacked { // stylelint-disable-line selector-no-qualifying-type
     display: block;
 }
+
+html.safari .widget-grid .widget-inner-stacked .widget-inner { // stylelint-disable-line selector-no-qualifying-type
+    flex-basis: auto !important; // stylelint-disable-line declaration-no-important
+}


### PR DESCRIPTION
https://github.com/philipwalton/flexbugs#11-min-and-max-size-declarations-are-ignored-when-wrapping-flex-items

### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer

@plentymarkets/ceres-io 