### PR TITLE
Fix/set component meta

### DIFF
--- a/resources/js/src/app/components/item/QuantityInput.vue
+++ b/resources/js/src/app/components/item/QuantityInput.vue
@@ -298,7 +298,7 @@ export default {
 
         fetchQuantityFromBasket()
         {
-            if (!isNullOrUndefined(this.min) && this.variationBasketQuantity >= this.min)
+            if (!isNullOrUndefined(this.min) && this.variationBasketQuantity >= this.min && this.variationBasketQuantity !== 0)
             {
                 // minimum quantity already in basket
                 this.compMin = this.compInterval;

--- a/resources/js/src/app/store/modules/singleItem/BaseItemModule.js
+++ b/resources/js/src/app/store/modules/singleItem/BaseItemModule.js
@@ -81,6 +81,11 @@ const actions =
 
                             const setComponentMeta = variation.documents[0].data.setComponents.find((setComponent) => setComponent.itemId === itemId );
 
+                            if (setComponentMeta.minimumOrderQuantity <= 0)
+                            {
+                                setComponentMeta.minimumOrderQuantity = 1;
+                            }
+
                             component.data.variation.minimumOrderQuantity = setComponentMeta.minimumOrderQuantity;
                             component.data.variation.maximumOrderQuantity = setComponentMeta.maximumOrderQuantity;
 

--- a/resources/js/src/app/store/modules/singleItem/BaseItemModule.js
+++ b/resources/js/src/app/store/modules/singleItem/BaseItemModule.js
@@ -79,6 +79,11 @@ const actions =
                             const itemId      = component.data.item.id;
                             const variationId = component.data.variation.id;
 
+                            const setComponentMeta = variation.documents[0].data.setComponents.find((setComponent) => setComponent.itemId === itemId );
+
+                            component.data.variation.minimumOrderQuantity = setComponentMeta.minimumOrderQuantity;
+                            component.data.variation.maximumOrderQuantity = setComponentMeta.maximumOrderQuantity;
+
                             // register a module for every set item
                             dispatch("registerItem", component);
                             commit(`${itemId}/setPleaseSelectVariationId`, variationId);

--- a/resources/js/src/app/store/modules/singleItem/ItemModule.js
+++ b/resources/js/src/app/store/modules/singleItem/ItemModule.js
@@ -20,20 +20,9 @@ const mutations =
     {
         setVariation(state, variation)
         {
-            state.variation = variation;
-            if (variation.documents.length > 0 && variation.documents[0].data.variation)
-            {
-                // Value needs to be > 0 to ensure correct price calculations
-                if ((variation.documents[0].data.variation.minimumOrderQuantity || 1 ) <= 0)
-                {
-                    state.variationOrderQuantity = variation.documents[0].data.variation.intervalOrderQuantity || 1;
-                }
-                else
-                {
-                    state.variationOrderQuantity = variation.documents[0].data.variation.minimumOrderQuantity;
-                }
-            }
+            variation = normalizeOrderQuantities(variation);
 
+            state.variation = variation;
             state.variationCache[variation.documents[0].id] = variation;
 
             if (state.initialVariationId <= 0)
@@ -349,6 +338,28 @@ const getters =
             return state.variation.documents && state.variation.documents[0] && state.variation.documents[0].data;
         }
     };
+
+function normalizeOrderQuantities(variation)
+{
+    if (variation.documents.length > 0 && variation.documents[0].data.variation)
+    {
+        if (isNullOrUndefined(variation.documents[0].data.variation.intervalOrderQuantity)
+            || variation.documents[0].data.variation.intervalOrderQuantity <= 0)
+        {
+            variation.documents[0].data.variation.intervalOrderQuantity = 1;
+        }
+
+        if (isNullOrUndefined(variation.documents[0].data.variation.minimumOrderQuantity)
+            || variation.documents[0].data.variation.minimumOrderQuantity <= 0)
+        {
+            variation.documents[0].data.variation.minimumOrderQuantity = 1;
+        }
+
+        state.variationOrderQuantity = variation.documents[0].data.variation.minimumOrderQuantity;
+    }
+
+    return variation;
+}
 
 export default
 {

--- a/resources/js/src/app/store/modules/singleItem/ItemModule.js
+++ b/resources/js/src/app/store/modules/singleItem/ItemModule.js
@@ -23,8 +23,8 @@ const mutations =
             state.variation = variation;
             if (variation.documents.length > 0 && variation.documents[0].data.variation)
             {
-                // Value needs to be >= 1 to ensure correct price calculations
-                state.variationOrderQuantity = Math.max(variation.documents[0].data.variation.minimumOrderQuantity || 1, 1);
+                // Value needs to be >= 0 to ensure correct price calculations
+                state.variationOrderQuantity = Math.max(variation.documents[0].data.variation.minimumOrderQuantity || 1, 0);
             }
 
             state.variationCache[variation.documents[0].id] = variation;

--- a/resources/js/src/app/store/modules/singleItem/ItemModule.js
+++ b/resources/js/src/app/store/modules/singleItem/ItemModule.js
@@ -120,6 +120,18 @@ const actions =
                         .get(`/rest/io/variations/${variationId}`, { template: "Ceres::Item.SingleItem", setPriceOnly: rootState.items.isItemSet })
                         .done(response =>
                         {
+                            // check if set component and replace relevant data
+                            if (rootState.items.itemSetId > 0)
+                            {
+                                const itemSetId = rootState.items.itemSetId;
+                                const setComponentMeta = rootState.items[itemSetId].setComponents.find(
+                                    (setComponent) => setComponent.itemId === response.documents[0].data.item.id
+                                );
+
+                                response.documents[0].data.variation.minimumOrderQuantity = setComponentMeta.minimumOrderQuantity;
+                                response.documents[0].data.variation.maximumOrderQuantity = setComponentMeta.maximumOrderQuantity;
+                            }
+
                             // store received variation data for later reuse
                             commit("setVariation", response);
                             commit("setIsAddToBasketLoading", 0, { root: true });

--- a/resources/js/src/app/store/modules/singleItem/ItemModule.js
+++ b/resources/js/src/app/store/modules/singleItem/ItemModule.js
@@ -22,6 +22,8 @@ const mutations =
         {
             variation = normalizeOrderQuantities(variation);
 
+            state.variationOrderQuantity = variation.documents[0].data.variation.minimumOrderQuantity;
+
             state.variation = variation;
             state.variationCache[variation.documents[0].id] = variation;
 
@@ -354,8 +356,6 @@ function normalizeOrderQuantities(variation)
         {
             variation.documents[0].data.variation.minimumOrderQuantity = 1;
         }
-
-        state.variationOrderQuantity = variation.documents[0].data.variation.minimumOrderQuantity;
     }
 
     return variation;

--- a/resources/js/src/app/store/modules/singleItem/ItemModule.js
+++ b/resources/js/src/app/store/modules/singleItem/ItemModule.js
@@ -23,7 +23,8 @@ const mutations =
             state.variation = variation;
             if (variation.documents.length > 0 && variation.documents[0].data.variation)
             {
-                state.variationOrderQuantity = variation.documents[0].data.variation.minimumOrderQuantity || 1;
+                // Value needs to be >= 1 to ensure correct price calculations
+                state.variationOrderQuantity = Math.max(variation.documents[0].data.variation.minimumOrderQuantity || 1, 1);
             }
 
             state.variationCache[variation.documents[0].id] = variation;

--- a/resources/js/src/app/store/modules/singleItem/ItemModule.js
+++ b/resources/js/src/app/store/modules/singleItem/ItemModule.js
@@ -23,8 +23,15 @@ const mutations =
             state.variation = variation;
             if (variation.documents.length > 0 && variation.documents[0].data.variation)
             {
-                // Value needs to be >= 0 to ensure correct price calculations
-                state.variationOrderQuantity = Math.max(variation.documents[0].data.variation.minimumOrderQuantity || 1, 0);
+                // Value needs to be > 0 to ensure correct price calculations
+                if ((variation.documents[0].data.variation.minimumOrderQuantity || 1 ) <= 0)
+                {
+                    state.variationOrderQuantity = variation.documents[0].data.variation.intervalOrderQuantity || 1;
+                }
+                else
+                {
+                    state.variationOrderQuantity = variation.documents[0].data.variation.minimumOrderQuantity;
+                }
             }
 
             state.variationCache[variation.documents[0].id] = variation;


### PR DESCRIPTION
### All changes meet the following requirements
- [ ] Changelog entry was added
- [x] Changes have been tested by the author
- [ ] Changes have been tested by the reviewer

@plentymarkets/ceres-io 

- Disallow zero or negative order quantitites
- Correctly set setComponent data in variation
- Fix a bug where basketQuantity is incorrectly read, when this.min === 0