### PR TITLE
Add warning when component override fails

### DIFF
--- a/resources/js/src/mount.js
+++ b/resources/js/src/mount.js
@@ -17,7 +17,16 @@ export default function(el, hydrating)
     if (this.$props.templateOverride)
     {
         // template element is references from property for current component instance
-        componentTemplate = replaceDelimiters((document.querySelector(this.$props.templateOverride) || {}).innerHTML);
+        const rawTemplate = (document.querySelector(this.$props.templateOverride) || {}).innerHTML;
+
+        if (isNullOrUndefined(rawTemplate))
+        {
+            console.warn("Overriding a component template has failed. Did you import the template into the DOM?");
+        }
+        else
+        {
+            componentTemplate = replaceDelimiters(rawTemplate);
+        }
     }
     else
     {


### PR DESCRIPTION
### All changes meet the following requirements
- [ ] Changelog entry was added
- [x] Changes have been tested by the author
- [ ] Changes have been tested by the reviewer

@plentymarkets/ceres-io 

The idea behind this PR is based on a case, where a partner used the templateOverride without the template imported into the DOM. The resulting errors were not helpful in seeing what went wrong. This PR alleviates the problem by steering the attention to the most likely error.