### PR TITLE
FIX/check for safeMode and isPreview before raw render in collapse widget

### DIFF
--- a/resources/scss/ceres/widgets/Common/_faq-widget.scss
+++ b/resources/scss/ceres/widgets/Common/_faq-widget.scss
@@ -1,11 +1,9 @@
 .widget-accordion {
     .card {
-        &:first-of-type {
-            border-bottom: $card-border-width solid $card-border-color;
-        }
+        border-bottom: 0;
 
-        &:nth-of-type(2) {
-            border-top: 0;
+        &:last-child {
+            border-bottom: $card-border-width solid $card-border-color;
         }
 
         button {

--- a/resources/views/Widgets/Common/CollapseWidget.twig
+++ b/resources/views/Widgets/Common/CollapseWidget.twig
@@ -51,7 +51,11 @@
                      aria-labelledby="heading_{{ collapseId }}_{{ loop.index }}"
                      data-parent="#accordion_{{ collapseId }}">
                     <div class="card-body">
-                        {{ collapseBox.text | raw }}
+                        {% if isPreview and isSafeMode %}
+                            {{ Twig.do("verbatim") }}<pre v-text="{{ collapseBox.text | json_encode }}"></pre>{{ Twig.do("endverbatim") }}
+                        {% else %}
+                            {{ collapseBox.text | raw }}
+                        {% endif %}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer

@plentymarkets/ceres-io 