### PR TITLE
StepByStepNavigationWidget - do not print component, when category is null; only load category by service, if it is null

### DIFF
--- a/resources/views/Widgets/Navigation/StepByStepNavigationWidget.twig
+++ b/resources/views/Widgets/Navigation/StepByStepNavigationWidget.twig
@@ -33,8 +33,12 @@
             </div>
 
         {% else %}
-            {{ Twig.set("category", "services.category.getCurrentCategory()") }}
-            {{ Twig.if("category is defined and category.level <= #{ maxLevel }") }}
+
+            {{ Twig.if("category is not defined or category is null") }}
+                {{ Twig.set("category", "services.category.getCurrentCategory()") }}
+            {{ Twig.endif() }}
+
+            {{ Twig.if("category is defined and category is not null and category.level <= #{ maxLevel }") }}
                 {{ Twig.set("children", Twig.call("services.category.getCurrentCategoryChildren", [Twig.var("category.id")])) }}
                 {{ Twig.set("chunkSize", numberOfColumns * numberOfRows)}}
 


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer

@plentymarkets/ceres-io 