### PR TITLE
Use metaRobots instead of null

### DIFF
--- a/resources/views/Homepage/Homepage.twig
+++ b/resources/views/Homepage/Homepage.twig
@@ -8,7 +8,7 @@
             {# Override default behaviour: Use empty title if no explicit meta title is defined #}
             {% block title category.details[0].metaTitle | default('') %}
             {% set metaDescription = category.details[0].metaDescription | default('') %}
-            {% set metaRobots = category.details[0].robots %}
+            {% set metaRobots = metaRobots %}
         {% else %}
             {% set metaDescription = trans('Ceres::Template.homepageMetaDescription') %}
             {% set metaRobots = ceresConfig.meta.robotsHome %}


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer

@plentymarkets/ceres-io 

robots is a nonexistent field on category_details. metaRobots comes from the CategoryContext