### PR TITLE
FIX: meta image for linked category image | ADD: default meta image

### DIFF
--- a/config.json
+++ b/config.json
@@ -3581,6 +3581,15 @@
         "Config.SEOTab": {
             "label": "Config.seoTab",
             "formFields": {
+                "meta.defaultImage": {
+                    "type": "inputFile",
+                    "required": false,
+                    "label": "Config.metaDefaultImage",
+                    "options": {
+                        "tooltip": "Config.metaDefaultImageTooltip",
+                        "defaultValue": ""
+                   }
+                },
                 "meta.robots_home": {
                     "type": "selectBox",
                     "required": false,

--- a/resources/lang/de/Config.properties
+++ b/resources/lang/de/Config.properties
@@ -448,6 +448,8 @@ metaRobotsLegalDisclosureLabel = Robots-Einstellungen für das Impressum
 metaRobotsPrivacyPolicyLabel = Robots-Einstellungen für die Datenschutzerklärung
 metaRobotsTermsAndConditionsLabel = Robots-Einstellungen für die AGB
 metaRobotsSearchResult = Robots-Einstellungen für die Suchergebnisse
+metaDefaultImage=Meta-Einstellung für das Standardbild
+metaDefaultImageTooltip=Dieses Bild wird in den Meta-Daten ausgegeben, wenn kein Artikel- / Kategoriebild verknüpft ist
 
 designTab = Design
 brandPrimaryLabel = Primärfarbe

--- a/resources/lang/en/Config.properties
+++ b/resources/lang/en/Config.properties
@@ -447,6 +447,8 @@ metaRobotsLegalDisclosureLabel = Robots for legal disclosure
 metaRobotsPrivacyPolicyLabel = Robots for privacy policy
 metaRobotsTermsAndConditionsLabel = Robots for terms and conditions
 metaRobotsSearchResult = Robots for search result
+metaDefaultImage=Meta setting for the default image
+metaDefaultImageTooltip=This image will be shown in the meta data if no article or category image is linked
 
 designTab = Design
 brandPrimaryLabel = Primary colour

--- a/resources/views/PageDesign/Partials/PageMetadata.twig
+++ b/resources/views/PageDesign/Partials/PageMetadata.twig
@@ -28,9 +28,9 @@
 {% endif %}
 
 {% if block('image') is defined %}
-    {% set image = block('image') | default(ceresConfig.header.companyLogo) %}
+    {% set image = block('image') | default(ceresConfig.meta.defaultImage) %}
 {% elseif details is not null %}
-    {% set image = details.imagePath | default(ceresConfig.header.companyLogo) %}
+    {% set image = details.imagePath | default(ceresConfig.meta.defaultImage) %}
 {% endif %}
 
 {% if block('title') is defined %}
@@ -47,8 +47,18 @@
 {% endif %}
 {% set title = title ~ trans("Ceres::Template.headerCompanyName") %}
 
+{% if image is null %}
+    {% set image = default(ceresConfig.header.companyLogo) %}
+{% elseif image starts with 'category/' %}
+    {% set image = webstoreConfig.domainSsl ~ "/documents/" ~ image %}
+{% endif %}
+
 {% if not (image starts with 'https://' or image starts with 'http://' or image starts with 'layout/') %}
     {% set image = plugin_path('Ceres') ~ "/" ~ image %}
+{% endif %}
+
+{% if image starts with 'http://' %}
+    {% set image = image | replace({'http://': 'https://'}) %}
 {% endif %}
 
 <meta name="robots" content="{% if forceNoIndex %}NOINDEX{% else %}{{ robots }}{% endif %}">

--- a/src/Config/CeresMetaConfig.php
+++ b/src/Config/CeresMetaConfig.php
@@ -14,6 +14,7 @@ class CeresMetaConfig extends PluginConfig
     public $robotsPrivacyPolicy;
     public $robotsTermsAndConditions;
     public $robotsSearchResult;
+    public $defaultImage;
     
     protected function getPluginName()
     {
@@ -30,5 +31,6 @@ class CeresMetaConfig extends PluginConfig
         $this->robotsPrivacyPolicy                  = $this->getTextValue( 'meta.robots_privacy_policy' , 'all' );
         $this->robotsTermsAndConditions             = $this->getTextValue( 'meta.robots_terms_and_conditions' , 'all' );
         $this->robotsSearchResult                   = $this->getTextValue( 'meta.robots_search_result' , 'all' );
+        $this->defaultImage                         = $this->getTextValue( 'meta.defaultImage' , '' );
     }
 }


### PR DESCRIPTION
### All changes meet the following requirements
- [ ] Changelog entry was added
- [x] Changes have been tested by the author
- [ ] Changes have been tested by the reviewer

@plentymarkets/ceres-io 

Zwei Probleme werden hier zusammen gelöst.
1. Verknüpfte Kategoriebilder werden nun korrekt ausgegeben
2. Wenn kein Bild verknüpft ist, wird nicht mehr das Ceres-Logo angezeigt

**Zu 1)**
**_Aktueller Zustand:_**
Das verknüpfte Kategoriebild wird im folgenden Code geladen:
https://github.com/plentymarkets/plugin-ceres/blob/76097ba3154905922c0cef2d9f52a0edda12a372/resources/views/PageDesign/Partials/PageMetadata.twig#L32-L34
Der Pfad ist aber nur "relative" und deshalb wird der im nachfolgen Code mit dem Link zum Ceres-Plugin erweitert:
https://github.com/plentymarkets/plugin-ceres/blob/76097ba3154905922c0cef2d9f52a0edda12a372/resources/views/PageDesign/Partials/PageMetadata.twig#L50-L52

Dadurch ist die komplette Url falsch und es wird kein Bild angezeigt.

**_Neuer Zustand:_**
Die "relative"-Url wird mit der Shopdomain korrekt erweitert:
https://github.com/Lauflust/plugin-ceres/blob/0561d5d5083cdf4706c2250cfa7afbdfdd57304f/resources/views/PageDesign/Partials/PageMetadata.twig#L52-L54

**Zu 2)**
**_Aktueller Zustand:_**
Desweiteren wird bisher als "default" auf das "_companyLogo_" aus der Ceres-Config zurückgegriffen, wenn kein Bild verknüpft ist. Diese Einstellung ist schon seit langem als "deprecated" markiert und wird deshalb nicht mehr in der Ceres-Config angezeigt (und wahrscheinlich von keinen mehr genutzt). Als Standardwert ist dort der "relative"-Pfad zum Ceres-Logo hinterlegt welches dann angezeigt wird. 

Ohne in jeder Kategorie und erstellter Content-Seite ein Bild zu verknüpfen, gibt es aktuell keine alternative Möglichkeit dies zu ändern!

**_Neuer Zustand:_**
In den Plugin-Einstellungen von Ceres ist nun im Tab SEO ein weiteres Feld mit der Möglichkeit ein Bild zu hinterlegen. Dies hat mehre Vorteile: Man muss nicht mehr in jeder Kategorie und Content-Seite ein Bild hinzufügen (unter Umständen immer das selbe Bild). Vor allem ist die empfohlene Bilder-Größe 1200x630px und würde unnötig Speicherplatz verbrauchen, wenn man dies überall hochladen muss (siehe dazu https://de.ryte.com/magazine/open-graph-tags). Falls man kein Bild verknüpft hat, wird dennoch ein ansprechendes Bild angezeigt. 

_Schaut man sich als Beispiel die Plentymarkets-Seite an so wird man feststellen, dass nicht nur das Bild mit http:// verlinkt ist, sondern auch das Bild-Format falsch ist und dadurch unschön ausseiht: (https://metatags.io/)_

Der neue Code ist wie folgt aufgebaut:
1. Das Bild wird geladen
https://github.com/Lauflust/plugin-ceres/blob/0561d5d5083cdf4706c2250cfa7afbdfdd57304f/resources/views/PageDesign/Partials/PageMetadata.twig#L30-L34

2. Sollte kein Bild verknüpft sein wird wieder als Fall-Back auf das "companyLogo" zurückgegriffen.
https://github.com/Lauflust/plugin-ceres/blob/0561d5d5083cdf4706c2250cfa7afbdfdd57304f/resources/views/PageDesign/Partials/PageMetadata.twig#L50-L51
https://github.com/Lauflust/plugin-ceres/blob/0561d5d5083cdf4706c2250cfa7afbdfdd57304f/resources/views/PageDesign/Partials/PageMetadata.twig#L56-L58

3. Als letzte "Sicherheit" wird das http durch https ersetzt, falls nötig.
https://github.com/Lauflust/plugin-ceres/blob/0561d5d5083cdf4706c2250cfa7afbdfdd57304f/resources/views/PageDesign/Partials/PageMetadata.twig#L60-L62