### PR TITLE
fix image proportions for safari of the payment/shipping icons

### DIFF
--- a/resources/scss/ceres/views/Templates/PaymentShippingSelect/_payment-shipping-select.scss
+++ b/resources/scss/ceres/views/Templates/PaymentShippingSelect/_payment-shipping-select.scss
@@ -57,7 +57,7 @@
             display: inline-block;
             vertical-align: middle;
 
-            // fix image proportions for safari (macOS) of the payment/shipping icons
+            // fix image proportions for safari of the payment/shipping icons
             > img {
                 object-fit: contain;
             }

--- a/resources/scss/ceres/views/Templates/PaymentShippingSelect/_payment-shipping-select.scss
+++ b/resources/scss/ceres/views/Templates/PaymentShippingSelect/_payment-shipping-select.scss
@@ -56,6 +56,11 @@
         .icon {
             display: inline-block;
             vertical-align: middle;
+
+            // fix image proportions for safari (macOS) of the payment/shipping icons
+            > img {
+                object-fit: contain;
+            }
         }
 
         .content {


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer

@plentymarkets/ceres-io 