### PR TITLE
FIX checking icon font initially

### DIFF
--- a/resources/views/PageDesign/Partials/Head.twig
+++ b/resources/views/PageDesign/Partials/Head.twig
@@ -201,21 +201,19 @@
         }
     }( typeof global !== "undefined" ? global : this ) );
 
-    if(document.fonts) {
-        document.fonts.addEventListener("loadingdone", function(evt) {
-            if(document.fonts.check("1em FontAwesome")) {
+    (function() {
+        var checkIconFont = function() {
+            if(!document.fonts || document.fonts.check("1em FontAwesome")) {
                 document.documentElement.classList.remove('icons-loading');
             }
-        });
+        };
 
-        window.addEventListener("load", function(evt) {
-            if(document.fonts.check("1em FontAwesome")) {
-                document.documentElement.classList.remove('icons-loading');
-            }
-        });
-    } else {
-        document.documentElement.classList.remove('icons-loading');
-    }
+        if(document.fonts) {
+            document.fonts.addEventListener("loadingdone", checkIconFont);
+            window.addEventListener("load", checkIconFont);
+        }
+        checkIconFont();
+    })();
 </script>
 
 {{ LayoutContainer.show("Ceres::Template.StyleOverwrite") }}


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer

@plentymarkets/ceres-io 

Der Fehler kam zustande, wenn FontAwesome bereits geladen war, bevor das Script ausgewertet wurde und `document.fonts` existiert. In dem Fall wurden EventListener zu Loading-Events registriert, die danach nicht mehr ausgelöst wurden.
Nachstellen lässt sich der Fehler, wenn man den Script-Block in ein `setTimeout()` kapselt.