### PR TITLE
add empty string as Home text for breadcrumb widget

### DIFF
--- a/resources/lang/de/Template.properties
+++ b/resources/lang/de/Template.properties
@@ -301,6 +301,7 @@ footerStoreFeature3 = "100 Tage Rückgaberecht"
 ; footer - Footer
 ; header - Header
 headerBg = "Bulgarisch"
+headerBreadcrumbHome = ""
 headerChangeDeliveryCountry = "Bitte ändern Sie Ihre Adresse, um das Lieferland zu wechseln."
 headerCn = "Chinesisch"
 headerCompanyName = "Ceres Webshop"

--- a/resources/lang/en/Template.properties
+++ b/resources/lang/en/Template.properties
@@ -301,6 +301,7 @@ footerStoreFeature3 = "100-day return policy"
 ; footer - Footer
 ; header - Header
 headerBg = "Bulgarian"
+headerBreadcrumbHome = ""
 headerChangeDeliveryCountry = "Please change your address in order to change the country of delivery."
 headerCn = "Chinese"
 headerCompanyName = "Ceres Webshop"

--- a/resources/lang/fr/Template.properties
+++ b/resources/lang/fr/Template.properties
@@ -299,6 +299,7 @@ footerStoreFeature3 = "Droit de retour de 100 jours"
 ; footer - Footer
 ; header - Header
 headerBg = "Bulgare"
+headerBreadcrumbHome = ""
 headerChangeDeliveryCountry = "Veuillez modifier votre adresse pour changer le pays fournisseur."
 headerCn = "Chinois"
 headerCompanyName = "Boutique en ligne Ceres"

--- a/resources/lang/nl/Template.properties
+++ b/resources/lang/nl/Template.properties
@@ -299,6 +299,7 @@ footerStoreFeature3 = "100 dagen retourrecht"
 ; footer - Footer
 ; header - Header
 headerBg = "Bulgaars"
+headerBreadcrumbHome = ""
 headerChangeDeliveryCountry = "Wijzig uw adres om het land van levering te wisselen."
 headerCn = "Chinees"
 headerCompanyName = "Ceres Webshop"

--- a/resources/lang/pl/Template.properties
+++ b/resources/lang/pl/Template.properties
@@ -299,6 +299,7 @@ footerStoreFeature3 = "100 dni na zwrot"
 ; footer - Footer
 ; header - Header
 headerBg = "Bułgarski"
+headerBreadcrumbHome = ""
 headerChangeDeliveryCountry = "Zmień adres, aby zmienić kraj dostawy."
 headerCn = "Chiński"
 headerCompanyName = "Sklep internetowy Ceres"

--- a/resources/views/Widgets/Header/BreadcrumbWidget.twig
+++ b/resources/views/Widgets/Header/BreadcrumbWidget.twig
@@ -37,7 +37,7 @@
                 <a href="{{ Twig.print('urls.home') }}">
                     <i class="fa fa-home" aria-hidden="true"></i>
                     {{ Twig.set("breadcrumbHome", "trans('Ceres::Template.headerBreadcrumbHome')") }}
-                    <span class="breadcrumb-home">{{ Twig.print("breadcrumbHome") }}</span>
+                        <span class="breadcrumb-home">{{ Twig.print("breadcrumbHome") }}</span>
                     {{ Twig.set('crumb', '
                         [
                             {

--- a/resources/views/Widgets/Header/BreadcrumbWidget.twig
+++ b/resources/views/Widgets/Header/BreadcrumbWidget.twig
@@ -35,10 +35,9 @@
         <ul class="breadcrumb container-max px-3 py-2 my-0 mx-auto">
             <li class="breadcrumb-item">
                 <a href="{{ Twig.print('urls.home') }}">
-                    <i class="fa fa-home" aria-hidden="true">
-                        {{ Twig.set("breadcrumbHome", "trans('Ceres::Template.headerBreadcrumbHome')") }}
-                        <span class="breadcrumb-home">{{ Twig.print("breadcrumbHome") }}</span>
-                    </i>
+                    <i class="fa fa-home" aria-hidden="true"></i>
+                    {{ Twig.set("breadcrumbHome", "trans('Ceres::Template.headerBreadcrumbHome')") }}
+                    <span class="breadcrumb-home">{{ Twig.print("breadcrumbHome") }}</span>
                     {{ Twig.set('crumb', '
                         [
                             {

--- a/resources/views/Widgets/Header/BreadcrumbWidget.twig
+++ b/resources/views/Widgets/Header/BreadcrumbWidget.twig
@@ -37,7 +37,7 @@
                 <a href="{{ Twig.print('urls.home') }}">
                     <i class="fa fa-home" aria-hidden="true"></i>
                     {{ Twig.set("breadcrumbHome", "trans('Ceres::Template.headerBreadcrumbHome')") }}
-                        <span class="breadcrumb-home">{{ Twig.print("breadcrumbHome") }}</span>
+                    <span class="breadcrumb-home">{{ Twig.print("breadcrumbHome") }}</span>
                     {{ Twig.set('crumb', '
                         [
                             {

--- a/resources/views/Widgets/Header/BreadcrumbWidget.twig
+++ b/resources/views/Widgets/Header/BreadcrumbWidget.twig
@@ -35,7 +35,10 @@
         <ul class="breadcrumb container-max px-3 py-2 my-0 mx-auto">
             <li class="breadcrumb-item">
                 <a href="{{ Twig.print('urls.home') }}">
-                    <i class="fa fa-home" aria-hidden="true"></i>
+                    <i class="fa fa-home" aria-hidden="true">
+                        {{ Twig.set("breadcrumbHome", "trans('Ceres::Template.headerBreadcrumbHome')") }}
+                        <span class="breadcrumb-home">{{ Twig.print("breadcrumbHome") }}</span>
+                    </i>
                     {{ Twig.set('crumb', '
                         [
                             {


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer

@plentymarkets/ceres-io 