### PR TITLE
FIX/sticky height detection

### DIFF
--- a/resources/scss/ceres/components/_sticky-element.scss
+++ b/resources/scss/ceres/components/_sticky-element.scss
@@ -2,7 +2,7 @@
     padding-bottom: .1px; // force disable margin collapse
 
     p:empty {
-        margin-bottom: 0; // remove margin of empty paragraph for correct height detection  
+        margin-bottom: 0; // remove margin of empty paragraph for correct height detection
     }
 }
 

--- a/resources/scss/ceres/components/_sticky-element.scss
+++ b/resources/scss/ceres/components/_sticky-element.scss
@@ -1,5 +1,9 @@
 .sticky-element {
     padding-bottom: .1px; // force disable margin collapse
+
+    p:empty {
+        margin-bottom: 0; // remove margin of empty paragraph for correct height detection  
+    }
 }
 
 .sticky-element.is-sticky {


### PR DESCRIPTION
margins of empty paragraphs count toward parent-parent height but not towards parent height

### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer

@plentymarkets/ceres-io 