### PR TITLE
FIX hide overflow of item lists to avoid widths > 100%

### DIFF
--- a/resources/views/Widgets/Common/ItemListWidget.twig
+++ b/resources/views/Widgets/Common/ItemListWidget.twig
@@ -150,7 +150,7 @@
                             {{ Twig.endfor() }}
                         </carousel>
                         <template #loading>
-                            <div class="row flex-nowrap">
+                            <div class="row flex-nowrap overflow-x-hidden">
                                 {{ Twig.for("item", "itemList.documents") }}
                                 <div class="category-item-placeholder invisible col-12 col-sm-6 col-md-3">
                                     <a href="{{ Twig.print("item.data | itemURL(buildUrlWithVariationId | json_encode)") }}" class="small">


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer

@plentymarkets/ceres-io 