### PR TITLE
BasketTotals- orderproperties with the option 'isShownAsAdditionalCosts' are not longer present in the basket totals

### DIFF
--- a/resources/js/src/app/components/basket/BasketTotals.vue
+++ b/resources/js/src/app/components/basket/BasketTotals.vue
@@ -238,7 +238,7 @@ export default {
 
             for (const basketItem of this.basketItems) {
                 const matchingProperties = basketItem.variation.data.properties.filter(property =>
-                    property.property.isShownAsAdditionalCosts && !property.property.isOrderProperty
+                    property.property.isShownAsAdditionalCosts && property.property.isOderProperty === false
                 );
 
                 for (const property of matchingProperties) {


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer

@plentymarkets/ceres-io 