### PR TITLE
change autocomplete setting for honeypot to 'new-password'

### DIFF
--- a/resources/js/src/app/components/customer/Registration.vue
+++ b/resources/js/src/app/components/customer/Registration.vue
@@ -41,7 +41,7 @@
                 </div>
             </div>
 
-            <input class="honey" type="text" name="username" autocomplete="off" tabindex="-1" v-model="honeypot">
+            <input class="honey" type="text" name="username" autocomplete="new-password" tabindex="-1" v-model="honeypot">
 
             <div class="col-12">
                 <address-input-group

--- a/resources/js/src/app/components/customer/login/ForgotPassword.vue
+++ b/resources/js/src/app/components/customer/login/ForgotPassword.vue
@@ -13,7 +13,7 @@
 						</div>
 						<div class="row">
 							<div class="col-12">
-                                <input class="honey" type="text" name="username" autocomplete="off" tabindex="-1" v-model="honeypot">
+                                <input class="honey" type="text" name="username" autocomplete="new-password" tabindex="-1" v-model="honeypot">
 								<div class="input-unit no-bottom" data-validate="mail">
 									<input type="email" name="email" autocomplete="email" :id="'mail' + _uid" v-model="username" data-autofocus>
 									<label :for="'mail' + _uid">{{ $translate("Ceres::Template.loginEmail") }}*</label>

--- a/resources/js/src/app/components/newsletter/NewsletterUnsubscribeInput.vue
+++ b/resources/js/src/app/components/newsletter/NewsletterUnsubscribeInput.vue
@@ -7,7 +7,7 @@
                     <input type="email" name="email" autocomplete="email" class="form-control" id="email-input-id" v-model="email">
                 </div>
 
-                <input class="honey" type="text" name="username" autocomplete="off" tabindex="-1" v-model="honeypot">
+                <input class="honey" type="text" name="username" autocomplete="new-password" tabindex="-1" v-model="honeypot">
 
                 <span class="input-group-btn">
                     <button type="submit" class="btn btn-primary btn-appearance float-right btn-medium btn-xs-max-width" @click="validateData" :disabled="isDisabled" :class="buttonSizeClass">

--- a/resources/views/Customer/Contact.twig
+++ b/resources/views/Customer/Contact.twig
@@ -137,7 +137,7 @@
                     {% endif %}
 
                     <div class="col-12 col-md-3 offset-md-9">
-                    <input class="honey" type="text" name="username" autocomplete="off" tabindex="-1">
+                    <input class="honey" type="text" name="username" autocomplete="new-password" tabindex="-1">
                         <button type="submit" class="btn btn-primary btn-block">
                             <i class="fa fa-paper-plane-o" aria-hidden="true"></i>
                             {{ trans("Ceres::Template.contactSend") }}

--- a/resources/views/Widgets/Form/MailFormWidget.twig
+++ b/resources/views/Widgets/Form/MailFormWidget.twig
@@ -52,7 +52,7 @@
                 <recaptcha></recaptcha>
             {{ Twig.endif() }}
 
-            <input class="honey" type="text" name="username" autocomplete="off" tabindex="-1">
+            <input class="honey" type="text" name="username" autocomplete="new-password" tabindex="-1">
 
             <div class="col-12 text-right">
                 <button type="submit" class="btn btn-{{ appearance }} {{ buttonSize }}">


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer

@plentymarkets/ceres-io 

Chrome ignores autocompletion for inputs associated with login flow. All honeypots with the name "username" thus can be affected by accidental autocompletion.

Using 'new-password' as the autocompletion setting disables autocompletion even for "login" inputs.
https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands