### PR TITLE
Allow reading of translations

### DIFF
--- a/resources/js/src/app/services/TranslationService.js
+++ b/resources/js/src/app/services/TranslationService.js
@@ -10,7 +10,8 @@ const TranslationService = (function($)
     _readTranslations();
 
     return {
-        translate: _translate
+        translate: _translate,
+        readTranslations: _readTranslations
     };
 
     function _readTranslations()

--- a/resources/js/src/base.js
+++ b/resources/js/src/base.js
@@ -195,6 +195,7 @@ import "./app/main";
 
 import TranslationService from "./app/services/TranslationService";
 window.ceresTranslate = TranslationService.translate;
+window.ceresReadTranslations = TranslationService.readTranslations;
 
 Vue.prototype.$translate = TranslationService.translate;
 Vue.prototype.$ceres = App;


### PR DESCRIPTION
This change allows plugin developers to add their own translations for Vue components, using the translation macro and the `TranslationService`.

*somePluginFile.twig*
```twig
{% import "Ceres::PageDesign.Macros.Translations" as Translations %}

{{ Translations.add( "YourPluginName", "Template" ) }}
```

*plugin-entrypoint.js*
```js
window.ceresReadTranslations();
```

### All changes meet the following requirements
- [ ] Changelog entry was added
- [x] Changes have been tested by the author
- [ ] Changes have been tested by the reviewer

@plentymarkets/ceres-io 