### PR TITLE
using intersect instead of lazy-hydrate

### DIFF
--- a/resources/views/PageDesign/Partials/Header/DefaultHeader.twig
+++ b/resources/views/PageDesign/Partials/Header/DefaultHeader.twig
@@ -211,9 +211,9 @@
                                                     <strong>{{ trans("Ceres::Template.headerSelectShippingCountry") }}</strong>
                                                     <hr>
                                                 </div>
-                                                <lazy-hydrate when-visible>
+                                                <intersect>
                                                     <shipping-country-select :disable-input="{{ services.template.isCheckout() | json_encode() }}"></shipping-country-select>
-                                                </lazy-hydrate>
+                                                </intersect>
                                             </div>
                                         </div>
                                     </div>

--- a/resources/views/PageDesign/Partials/Header/DefaultHeader.twig
+++ b/resources/views/PageDesign/Partials/Header/DefaultHeader.twig
@@ -213,6 +213,9 @@
                                                 </div>
                                                 <intersect>
                                                     <shipping-country-select :disable-input="{{ services.template.isCheckout() | json_encode() }}"></shipping-country-select>
+                                                    <template #loading>
+                                                        <div class="row" style="height:1px;"></div>
+                                                    </template>
                                                 </intersect>
                                             </div>
                                         </div>

--- a/resources/views/Widgets/Header/TopBarWidget.twig
+++ b/resources/views/Widgets/Header/TopBarWidget.twig
@@ -331,6 +331,9 @@
                                         </div>
                                         <intersect>
                                             <shipping-country-select :disable-input="{{ Twig.print(Twig.call('services.template.isCheckout') ~ ' | json_encode') }}"></shipping-country-select>
+                                            <template #loading>
+                                                <div class="row" style="height:1px;"></div>
+                                            </template>
                                         </intersect>
                                     </div>
                                 </div>

--- a/resources/views/Widgets/Header/TopBarWidget.twig
+++ b/resources/views/Widgets/Header/TopBarWidget.twig
@@ -329,9 +329,9 @@
                                             <strong>{{ Twig.print('trans("Ceres::Template.headerSelectShippingCountry")') }}</strong>
                                             <hr>
                                         </div>
-                                        <lazy-hydrate when-visible>
+                                        <intersect>
                                             <shipping-country-select :disable-input="{{ Twig.print(Twig.call('services.template.isCheckout') ~ ' | json_encode') }}"></shipping-country-select>
-                                        </lazy-hydrate>
+                                        </intersect>
                                     </div>
                                 </div>
                             {% endif %}


### PR DESCRIPTION
### All changes meet the following requirements
- [ ] Changelog entry was added
- [ ] Changes have been documented
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer

@plentymarkets/ceres-io

using intersect instead of lazy-hydrate as fallback in case of not using the vue-ssr feature.