### PR TITLE
Include QuantityInput in AddToBasket component

### DIFF
--- a/resources/js/src/app/components/basket/AddToBasket.vue
+++ b/resources/js/src/app/components/basket/AddToBasket.vue
@@ -82,11 +82,17 @@ import { navigateTo } from "../../services/UrlService";
 import { isNullOrUndefined, isDefined } from "../../helper/utils";
 import { mapState } from "vuex";
 import { ButtonSizePropertyMixin } from "../../mixins/buttonSizeProperty.mixin";
+import QuantityInput from "../item/QuantityInput.vue";
 
 const NotificationService = require("../../services/NotificationService");
 
 export default {
     mixins: [ButtonSizePropertyMixin],
+    
+    components:
+    {
+        QuantityInput
+    },
 
     props:
     {


### PR DESCRIPTION
When including QuantityInput.vue in AddToBasket.vue there will be no chain loading of two components. Instead only AddToBasket.vue is loaded from server which speeds up page loading.