### PR TITLE
Remove checkout components from the ssr javascript

### DIFF
--- a/resources/js/src/app.js
+++ b/resources/js/src/app.js
@@ -174,9 +174,6 @@ export function createApp(options)
     Vue.component("lazy-hydrate", LazyHydrate);
     Vue.use(script2);
 
-    // CHECKOUT
-    Vue.component("edit-coupon-overlay", () => import("./app/components/myAccount/EditCouponOverlay.vue"));
-
     Vue.prototype.$translate = TranslationService.translate;
     Vue.prototype.$ceres = App;
 

--- a/resources/js/src/app.js
+++ b/resources/js/src/app.js
@@ -36,33 +36,6 @@ import LazyHydrate from "vue-lazy-hydration";
 import ClientOnly from "./app/components/common/ClientOnly.vue";
 import script2 from "./app/plugins/script2";
 
-// CHECKOUT
-import "./app/components/checkout/AcceptGtcCheck";
-import "./app/components/checkout/Checkout";
-import "./app/components/checkout/ContactWishInput";
-import "./app/components/checkout/CustomerSignInput";
-import "./app/components/checkout/PaymentProviderSelect";
-import "./app/components/checkout/PlaceOrder";
-import "./app/components/checkout/ShippingPrivacyHintCheck";
-import "./app/components/checkout/ShippingProfileSelect";
-import "./app/components/checkout/SubscribeNewsletterCheck";
-
-import "./app/components/customer/AddressSelect/AddressHeader";
-import "./app/components/customer/AddressSelect/InvoiceAddressSelect";
-import "./app/components/customer/AddressSelect/ShippingAddressSelect";
-
-import "./app/components/myAccount/AccountSettings";
-import "./app/components/myAccount/BankDataSelect";
-import "./app/components/myAccount/ChangePaymentMethod";
-import "./app/components/myAccount/MyAccount";
-import "./app/components/myAccount/OrderDocuments";
-
-// // legacy non-shopbuilder components
-import "./app/components/myAccount/History";
-
-// // new shopbuilder-only component
-import "./app/components/myAccount/OrderHistoryList";
-import "./app/components/myAccount/OrderReturnHistoryList";
 
 // =========================
 // SERVICES


### PR DESCRIPTION
### All changes meet the following requirements
- [ ] Changelog entry was added
- [ ] Changes have been documented
- [x] Changes have been tested by the author
- [ ] Changes have been tested by the reviewer

@plentymarkets/ceres-io

SSR shouldn't work on pages where the checkout-asset is loaded therefore is no need for the checkout components to be included in the ssr scripts. 