### PR TITLE
Pass vue errors to core renderer to be thrown during ssr

### DIFF
--- a/resources/js/src/entry-server.js
+++ b/resources/js/src/entry-server.js
@@ -19,7 +19,7 @@ function createApp(context)
             Vue.config.errorHandler = (err, vm, info) =>
             {
                 context.throwError({
-                    message: `[Vue error]: Error in ${ info }: "${ err.toString() }"`,
+                    message: `[Vue error]: Error in ${ info }: "${ err.toString() }". Activate development mode in Ceres for detailed stack trace.`,
                     stack: err.stack
                 });
             };
@@ -30,7 +30,7 @@ function createApp(context)
             Vue.config.warnHandler = (msg, vm, trace) =>
             {
                 context.throwError({
-                    message: `[Vue error]: ${ msg }`,
+                    message: `[Vue error]: ${ msg } ${ trace }`,
                     stack: trace.trim()
                 });
             };

--- a/resources/js/src/entry-server.js
+++ b/resources/js/src/entry-server.js
@@ -14,6 +14,7 @@ function createApp(context)
     return new Promise((resolve, reject) =>
     {
         if(process.env.NODE_ENV === "production") {
+            // for minified production bundle, only error handler is available
             Vue.config.errorHandler = (err, vm, info) => {
                 context.throwError({
                     message: `Error in ${ info }: "${ err.toString() }"`,
@@ -21,6 +22,7 @@ function createApp(context)
                 });
             }
         } else {
+            // use more detailed warn handler for development bundles
             Vue.config.warnHandler = (msg, vm, trace) => {
                 context.throwError({
                     message: msg,

--- a/resources/js/src/entry-server.js
+++ b/resources/js/src/entry-server.js
@@ -13,22 +13,27 @@ function createApp(context)
 {
     return new Promise((resolve, reject) =>
     {
-        if(process.env.NODE_ENV === "production") {
+        if (process.env.NODE_ENV === "production")
+        {
             // for minified production bundle, only error handler is available
-            Vue.config.errorHandler = (err, vm, info) => {
+            Vue.config.errorHandler = (err, vm, info) =>
+            {
                 context.throwError({
                     message: `Error in ${ info }: "${ err.toString() }"`,
                     stack: err.stack
                 });
-            }
-        } else {
+            };
+        }
+        else
+        {
             // use more detailed warn handler for development bundles
-            Vue.config.warnHandler = (msg, vm, trace) => {
+            Vue.config.warnHandler = (msg, vm, trace) =>
+            {
                 context.throwError({
                     message: msg,
                     stack: trace.trim()
                 });
-            }
+            };
         }
         // defines if the render location is the server
         App.isSSR = true;

--- a/resources/js/src/entry-server.js
+++ b/resources/js/src/entry-server.js
@@ -19,7 +19,7 @@ function createApp(context)
             Vue.config.errorHandler = (err, vm, info) =>
             {
                 context.throwError({
-                    message: `Error in ${ info }: "${ err.toString() }"`,
+                    message: `[Vue error]: Error in ${ info }: "${ err.toString() }"`,
                     stack: err.stack
                 });
             };
@@ -30,7 +30,7 @@ function createApp(context)
             Vue.config.warnHandler = (msg, vm, trace) =>
             {
                 context.throwError({
-                    message: msg,
+                    message: `[Vue error]: ${ msg }`,
                     stack: trace.trim()
                 });
             };

--- a/resources/js/src/entry-server.js
+++ b/resources/js/src/entry-server.js
@@ -13,6 +13,21 @@ function createApp(context)
 {
     return new Promise((resolve, reject) =>
     {
+        if(process.env.NODE_ENV === "production") {
+            Vue.config.errorHandler = (err, vm, info) => {
+                context.throwError({
+                    message: `Error in ${ info }: "${ err.toString() }"`,
+                    stack: err.stack
+                });
+            }
+        } else {
+            Vue.config.warnHandler = (msg, vm, trace) => {
+                context.throwError({
+                    message: msg,
+                    stack: trace.trim()
+                });
+            }
+        }
         // defines if the render location is the server
         App.isSSR = true;
         App.isSSREnabled = App.config.log.performanceSsr;


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been documented
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer

@plentymarkets/ceres-io

**requires** https://github.com/plentymarkets/module-webshop/pull/267

Vue-interne Fehler werden jetzt als php Exception ausgegeben. Zum Nachstellen z.B. in einem created()-Hook auf jQuery zugreifen.