### PR TITLE
Fix "FIX ceres store for after script container" for deactivated SSR

### DIFF
--- a/resources/js/src/base.js
+++ b/resources/js/src/base.js
@@ -211,6 +211,13 @@ Vue.prototype.$ceres = App;
 
 const store = createStore();
 
+if (window.__INITIAL_STATE__)
+{
+    store.replaceState(window.__INITIAL_STATE__);
+}
+
+window.ceresStore = store;
+
 initServerStore(store);
 initClientStore(store);
 initClientListeners(store);

--- a/resources/js/src/base.js
+++ b/resources/js/src/base.js
@@ -211,11 +211,6 @@ Vue.prototype.$ceres = App;
 
 const store = createStore();
 
-if (window.__INITIAL_STATE__)
-{
-    store.replaceState(window.__INITIAL_STATE__);
-}
-
 window.ceresStore = store;
 
 initServerStore(store);

--- a/resources/js/src/entry-client.js
+++ b/resources/js/src/entry-client.js
@@ -34,6 +34,11 @@ window.createApp = (selector) =>
 
 const store = createStore();
 
+if (window.__INITIAL_STATE__)
+{
+    store.replaceState(window.__INITIAL_STATE__);
+}
+
 window.jQuery = jQuery;
 window.$ = jQuery;
 window.Vue = Vue;

--- a/resources/js/src/entry-client.js
+++ b/resources/js/src/entry-client.js
@@ -34,11 +34,6 @@ window.createApp = (selector) =>
 
 const store = createStore();
 
-if (window.__INITIAL_STATE__)
-{
-    store.replaceState(window.__INITIAL_STATE__);
-}
-
 window.jQuery = jQuery;
 window.$ = jQuery;
 window.Vue = Vue;


### PR DESCRIPTION
### All changes meet the following requirements
- [ ] Changelog entry was added
- [ ] Changes have been documented
- [x] Changes have been tested by the author
- [ ] Changes have been tested by the reviewer

@plentymarkets/ceres-io
Im [PR 2886  ](https://github.com/plentymarkets/plugin-ceres/pull/2886/) wurde vergessen die Anpassung auch für den "Nicht-SSR" Bereich zu machen. Ohne die Anpassung kommt es ansonsten zu weißen Seiten und diveresen Browser-Konsolen Fehlern.