### PR TITLE
OrderReturnHistoryListItem - fix missing returns if the property type was 'file'

### DIFF
--- a/resources/js/src/app/components/myAccount/OrderReturnHistoryListItem.js
+++ b/resources/js/src/app/components/myAccount/OrderReturnHistoryListItem.js
@@ -21,6 +21,14 @@ export default Vue.component("order-return-history-list-item", {
         }
     },
 
+    computed:
+    {
+        useVariationOrderProperties()
+        {
+            return !!App.useVariationOrderProperties;
+        }
+    },
+
     data()
     {
         return {

--- a/resources/js/src/app/components/myAccount/OrderReturnHistoryListItem.js
+++ b/resources/js/src/app/components/myAccount/OrderReturnHistoryListItem.js
@@ -21,14 +21,6 @@ export default Vue.component("order-return-history-list-item", {
         }
     },
 
-    computed:
-    {
-        useVariationOrderProperties()
-        {
-            return !!App.useVariationOrderProperties;
-        }
-    },
-
     data()
     {
         return {

--- a/resources/views/MyAccount/Components/OrderReturnHistoryListItem.twig
+++ b/resources/views/MyAccount/Components/OrderReturnHistoryListItem.twig
@@ -46,7 +46,7 @@
                                 <div v-for="property in orderItem.orderProperties" {{ set_testing_attr("data-testing", "return-history-property") }}>
                                     <b>${ property.name }</b>
                                     <span v-if="property.type === 'file'">
-                                        <a v-if="App.useVariationOrderProperties === 1" :href="property.fileUrl" target="_blank" class="text-primary text-appearance">
+                                        <a v-if="useVariationOrderProperties" :href="property.fileUrl" target="_blank" class="text-primary text-appearance">
                                             <i class="fa fa-external-link" aria-hidden="true"></i>
                                             ${ property.value | fileName }
                                         </a>

--- a/resources/views/MyAccount/Components/OrderReturnHistoryListItem.twig
+++ b/resources/views/MyAccount/Components/OrderReturnHistoryListItem.twig
@@ -46,7 +46,7 @@
                                 <div v-for="property in orderItem.orderProperties" {{ set_testing_attr("data-testing", "return-history-property") }}>
                                     <b>${ property.name }</b>
                                     <span v-if="property.type === 'file'">
-                                        <a v-if="useVariationOrderProperties" :href="property.fileUrl" target="_blank" class="text-primary text-appearance">
+                                        <a v-if="$ceres.useVariationOrderProperties" :href="property.fileUrl" target="_blank" class="text-primary text-appearance">
                                             <i class="fa fa-external-link" aria-hidden="true"></i>
                                             ${ property.value | fileName }
                                         </a>

--- a/resources/views/PageDesign/PageDesign.twig
+++ b/resources/views/PageDesign/PageDesign.twig
@@ -201,7 +201,7 @@
         "initialPleaseSelect": {{ webstoreConfig.attributeSelectDefaultOption | default(0) }},
         "publicPath": "{{ plugin_path('Ceres') ~ '/js/dist/' }}",
         "isCheapestSorting": "{{ services.template.isCheapestSorting() }}",
-        "useVariationOrderProperties": {{ webstoreConfig.useVariationOrderProperties | default(0) }},
+        "useVariationOrderProperties": {% if webstoreConfig.useVariationOrderProperties | default(0) %}true{% else %}false{% endif %},
         "initialData": {
             "shippingCountries": {{ services.country.getActiveCountriesList() | filterFields(["id", "currLangName", "isoCode2", "states.id", "states.name", "vatCodes"]) | json_encode | raw }},
             "shippingCountryId": {{ services.checkout.getShippingCountryId() }},


### PR DESCRIPTION
### All changes meet the following requirements
- ~Changelog entry was added~
- [ ] Changes have been documented
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer

@plentymarkets/ceres-io
