### PR TITLE
ItemGridWidget.php - limit the maximum items to 50, to prevent exhaustion errors

### DIFF
--- a/src/Widgets/Category/ItemGridWidget.php
+++ b/src/Widgets/Category/ItemGridWidget.php
@@ -101,6 +101,9 @@ class ItemGridWidget extends BaseWidget
 
         $itemListOptions = [];
         $itemListOptions = SearchOptions::validateItemListOptions($itemListOptions, SearchOptions::SCOPE_CATEGORY);
+        // limit the maximum of items to 20, to prevent memory exhaustion errors
+        $itemListOptions['itemsPerPage'] = min(20, $itemListOptions['itemsPerPage']);
+
         $itemList        = $itemListService->getItemList(
             ItemListService::TYPE_RANDOM,
             null,

--- a/src/Widgets/Category/ItemGridWidget.php
+++ b/src/Widgets/Category/ItemGridWidget.php
@@ -101,8 +101,8 @@ class ItemGridWidget extends BaseWidget
 
         $itemListOptions = [];
         $itemListOptions = SearchOptions::validateItemListOptions($itemListOptions, SearchOptions::SCOPE_CATEGORY);
-        // limit the maximum of items to 20, to prevent memory exhaustion errors
-        $itemListOptions['itemsPerPage'] = min(20, $itemListOptions['itemsPerPage']);
+        // limit the maximum of items to 50, to prevent memory exhaustion errors
+        $itemListOptions['itemsPerPage'] = min(50, $itemListOptions['itemsPerPage']);
 
         $itemList        = $itemListService->getItemList(
             ItemListService::TYPE_RANDOM,


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been documented
- [x] Changes have been tested by the author
- [ ] Changes have been tested by the reviewer

@plentymarkets/ceres-io
