### PR TITLE
Fix for empty TagList

### DIFF
--- a/resources/js/src/app/components/item/TagList.vue
+++ b/resources/js/src/app/components/item/TagList.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="tags" class="pt-1 pb-1">
+    <div v-if="tags && tags.length > 0" class="pt-1 pb-1">
         <template v-if="isTagRouteEnabled">
             <a
                 v-for="tag in tags"


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been documented
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer

@plentymarkets/plentyshop
Hat ein Artikel ein Tag welches allerdings nicht für den Mandanten freigeschaltet ist, wird dennoch ein leeres Div mit den Padding-Klassen ausgegeben. Dieser Fix behebt dieses Problem.