### PR TITLE
FIX HeaderScroll - .childern.forEach not found

### DIFF
--- a/resources/js/src/app/helper/HeaderScroller.js
+++ b/resources/js/src/app/helper/HeaderScroller.js
@@ -75,7 +75,7 @@ export default class HeaderScroller
         this.headerHeight = 0;
         this.allHeaderChildrenHeights = [];
 
-        this.headerParent?.children.forEach(element =>
+        Array.from(this.headerParent?.children).forEach(element =>
         {
             let elementHeight = 0;
 
@@ -97,7 +97,7 @@ export default class HeaderScroller
         {
             let zIndex = 100;
 
-            this.headerParent?.children.forEach(element =>
+            Array.from(this.headerParent?.children).forEach(element =>
             {
                 element.style.zIndex = zIndex--;
             });


### PR DESCRIPTION
### All changes meet the following requirements
- [ ] Changelog entry was added
- [ ] Changes have been documented
- [ ] Changes have been tested by the author
- [ ] Changes have been tested by the reviewer

@plentymarkets/plentyshop
