### PR TITLE
FIX: Show order properties also when current variation is not salable

### DIFF
--- a/resources/js/src/app/components/item/OrderPropertyList.vue
+++ b/resources/js/src/app/components/item/OrderPropertyList.vue
@@ -126,7 +126,7 @@ export default {
 
         renderOrderPropertyList()
         {
-            return (this.$store.getters[`${this.itemId}/currentItemVariation`].filter.isSalable && this.variationGroupedProperties.length) || App.isShopBuilder;
+            return this.variationGroupedProperties.length || App.isShopBuilder;
         },
 
         variationMissingProperties()


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been documented
- [x] Changes have been tested by the author
- [ ] Changes have been tested by the reviewer

@plentymarkets/plentyshop
