### PR TITLE
FIX - ItemModule.js - prevent errors on required radios, when one in the group is already selected

### DIFF
--- a/resources/js/src/app/store/modules/singleItem/ItemModule.js
+++ b/resources/js/src/app/store/modules/singleItem/ItemModule.js
@@ -326,7 +326,7 @@ const getters =
                         });
                     }
 
-                    _removeRadioValueProperties(state.variation, missingProperties);
+                    missingProperties = _removeRadioValueProperties(state.variation, missingProperties);
 
                     return missingProperties;
                 }
@@ -361,6 +361,9 @@ function normalizeOrderQuantities(variation)
     return variation;
 }
 
+/**
+ * Check all properties if a radio in a group is selected. If so, remove the group from the validation.
+ */
 function _removeRadioValueProperties(variation, missingProperties = [])
 {
     if (missingProperties.length)


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [ ] Changes have been documented
- [x] Changes have been tested by the author
- [ ] Changes have been tested by the reviewer

@plentymarkets/plentyshop
