### PR TITLE
FIX ItemListWidget - set item data via ref to prevent encoding of accents

### DIFF
--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -97,6 +97,17 @@
 - Im Zuge des Releases von Ceres 5.0.50 gab es Änderungen an Template-Dateien, die für Theme-Entwickler relevant sind. Die Verlinkung führt direkt zu der umgesetzten Änderung in den entsprechenden Dateien.
 - [resources/views/Checkout/Macros/OrderTotals.twig](https://github.com/plentymarkets/plugin-ceres/pull/3246/files#diff-8ea271aa9d97b46230e0f009330b3da0be4020cf00d5e8f214bcfb05425186d2)
 
+## v5.0.50 (2022-XX-XX) <a href="https://github.com/plentymarkets/plugin-ceres/compare/5.0.49...5.0.50" target="_blank" rel="noopener"><b>Übersicht aller Änderungen</b></a>
+
+### Behoben
+
+- Artikelnamen mit Accents im Artikellisten-Widget wurden mit aktivem SSR als HTML-Entities angezeigt. Dies wurde behoben.
+
+### Angepasste Templates
+
+- Im Zuge des Releases von Ceres 5.0.49 gab es Änderungen an Template-Dateien, die für Theme-Entwickler relevant sind. Die Verlinkung führt direkt zu der umgesetzten Änderung in den entsprechenden Dateien.
+- [resources/js/src/app/components/itemList/CategoryItem.vue](https://github.com/plentymarkets/plugin-ceres/pull/3265/files#diff-4c35af622ef09ba8949eb1c47557e3e6651b088291a0d2e2463c9244007b5516)
+
 ## v5.0.49 (2022-04-11) <a href="https://github.com/plentymarkets/plugin-ceres/compare/5.0.48...5.0.49" target="_blank" rel="noopener"><b>Übersicht aller Änderungen</b></a>
 
 ### Geändert

--- a/resources/views/Widgets/Common/ItemListWidget.twig
+++ b/resources/views/Widgets/Common/ItemListWidget.twig
@@ -148,7 +148,8 @@
                             {{ Twig.for("item", "itemList.documents") }}
                                 <template slot="items">
                                     <category-item
-                                        :item-data="{{ Twig.print("item.data | json_encode") }}"
+                                        {% if isPreview %}:item-data="{{ Twig.print("item.data | json_encode") }}"{% else %}
+                                        item-data-ref="{{ Twig.print("item.data | json_data") }}"{% endif %}
                                         :decimal-count="{{ Twig.print("ceresConfig.item.storeSpecial | default(0) | json_encode") }}"
                                         :disable-carousel-on-mobile="{{ Twig.print("itemList.documents | length") }} > {{ itemsPerPage }}"
                                         {% if spacingPadding | length > 0 %}padding-classes="{{ spacingPadding }}"{% endif %}


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been documented
- [x] Changes have been tested by the author
- [ ] Changes have been tested by the reviewer

@plentymarkets/plentyshop
