### PR TITLE
fix unnecessary space in OrderPropertyListItem.vue

### DIFF
--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -5,6 +5,7 @@
 ### Behoben
 
 - Wenn die Cookiebar viel Text enthielt konnte sie teilweise aus dem Bildschirm ragen. In diesem Fall wird sie zukünftig scrollbar
+- Überflüssige Leerzeichen in der OrderPropertyListItem.vue entfernt
 
 ## v5.0.54 (2022-08-08) <a href="https://github.com/plentymarkets/plugin-ceres/compare/5.0.53...5.0.54" target="_blank" rel="noopener"><b>Übersicht aller Änderungen</b></a>
 

--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - If the cookie bar contained a lot of text, it could partially protrude from the screen. In this situation it will be scrollable from now on 
+- Removed unnecessary spaces in OrderPropertyListItem.vue
 
 ## v5.0.54 (2022-08-08) <a href="https://github.com/plentymarkets/plugin-ceres/compare/5.0.53...5.0.54" target="_blank" rel="noopener"><b>Overview of all changes</b></a>
 

--- a/resources/js/src/app/components/item/OrderPropertyListItem.vue
+++ b/resources/js/src/app/components/item/OrderPropertyListItem.vue
@@ -12,7 +12,7 @@
             <label class="d-flex">
                 <span class="text-truncate">{{ property.names.name }}</span>
                 <strong class="ml-1">
-                    <template v-if="surcharge > 0">( {{ inclOrPlus }} {{ surcharge | currency }})</template>
+                    <template v-if="surcharge > 0">({{ inclOrPlus }} {{ surcharge | currency }})</template>
                     <span>{{ footnotes }} {{ requiredFootnotes }}</span>
                 </strong>
             </label>
@@ -45,7 +45,7 @@
                     :data-testing="'order-property-label-' + inputType">
                 <span class="text-wrap">{{ property.names.name }}</span>
                 <strong class="ml-1">
-                    <template v-if="surcharge > 0">( {{ inclOrPlus }} {{ surcharge | currency }})</template>
+                    <template v-if="surcharge > 0">({{ inclOrPlus }} {{ surcharge | currency }})</template>
                     <span>{{ footnotes }} {{ requiredFootnotes }}</span>
                 </strong>
             </label>
@@ -65,7 +65,7 @@
                 <label class="d-flex w-100" for="order-property-input-select">
                     <span class="text-truncate">{{ property.names.name }}</span>
                     <strong class="ml-1">
-                        <template v-if="surcharge > 0">( {{ inclOrPlus }} {{ surcharge | currency }})</template>
+                        <template v-if="surcharge > 0">({{ inclOrPlus }} {{ surcharge | currency }})</template>
                         <span>{{ footnotes }} {{ requiredFootnotes }}</span>
                     </strong>
                 </label>
@@ -87,7 +87,7 @@
                 <span class="input-unit-label d-flex">
                     <span class="text-truncate">{{ property.names.name }}</span>
                     <strong class="ml-1">
-                        <template v-if="surcharge > 0">( {{ inclOrPlus }} {{ surcharge | currency }})</template>
+                        <template v-if="surcharge > 0">({{ inclOrPlus }} {{ surcharge | currency }})</template>
                         <span>{{ footnotes }} {{ requiredFootnotes }}</span>
                     </strong>
                 </span>


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been documented
- [ ] Changes have been tested by the author
- [ ] Changes have been tested by the reviewer

@plentymarkets/plentyshop
