### PR TITLE
fix: clean output dir before bundling

### DIFF
--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -10,6 +10,7 @@
 
 - Für die Seitennummerierung auf Artikelkategorieseiten wurden in Version 5.0.55 `aria-label` verbaut. Hier kam es zu einem Fehler, dieser wurde behoben.
 - Auf Bestellbestätigungsseiten, die über den ShopBuilder erstellt wurden, wurde das voraussichtliche Versanddatum nicht im korrekten Format angezeigt. Dies wurde behoben.
+- Das Skript zum Kompilieren von SCSS-Dateien (`bundleSass.js`) entfernt jetzt alte Dateien aus dem Zielordner. Durch diese Anpassungen können einige Import-Fehler beim Bereitstellen von Plugins behoben werden.
 
 ### Angepasste Templates
 

--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -10,6 +10,7 @@
 
 - Für die Seitennummerierung auf Artikelkategorieseiten wurden in Version 5.0.55 `aria-label` verbaut. Hier kam es zu einem Fehler, dieser wurde behoben.
 - Auf Bestellbestätigungsseiten, die über den ShopBuilder erstellt wurden, wurde das voraussichtliche Versanddatum nicht im korrekten Format angezeigt. Dies wurde behoben.
+- Das Skript zum Kompilieren von SCSS-Dateien (`bundleSass.js`) entfernt jetzt alte Dateien aus dem Zielordner. Durch diese Anpassungen können einige Import-Fehler beim Bereitstellen von Plugins behoben werden.
 
 ### Changed templates
 

--- a/tools/bundleSass.js
+++ b/tools/bundleSass.js
@@ -6,7 +6,7 @@ var postcssSCSS = require('postcss-scss');
 var glob = require('glob');
 
 // Clean output dir
-glob.sync(path.resolve(__dirname, '../resources/css/*.scss')).forEach(file =>
+glob.sync(path.resolve(__dirname, '../resources/css/*.s[a|c]ss')).forEach(file =>
     {
         fs.rmSync(file);
     })

--- a/tools/bundleSass.js
+++ b/tools/bundleSass.js
@@ -5,6 +5,12 @@ var postcss = require('postcss');
 var postcssSCSS = require('postcss-scss');
 var glob = require('glob');
 
+// Clean output dir
+glob.sync(path.resolve(__dirname, '../resources/css/*.scss')).forEach(file =>
+    {
+        fs.rmSync(file);
+    })
+
 /*
  CLASS ImportTree
  */


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been documented: https://github.com/plentymarkets/plenty-developers-docs/pull/105
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer
