### PR TITLE
fix: background img in footer no longer at full width

### DIFF
--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -5,6 +5,7 @@
 ### Behoben
 
 - Leeres Anker-Tag im Bilderbox-Widget.
+- Vollbildbreite des Hintergrundbild-Widgets in der Fußzeile
 
 ## v5.0.63 (2024-04-11) <a href="https://github.com/plentymarkets/plugin-ceres/compare/5.0.62...5.0.63" target="_blank" rel="noopener"><b>Übersicht aller Änderungen</b></a>
 

--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Empty anchor tag on image box widget.
+- Fullscreen width of background image widget in footer
 
 ## v5.0.63 (2024-04-11) <a href="https://github.com/plentymarkets/plugin-ceres/compare/5.0.62...5.0.63" target="_blank" rel="noopener"><b>Overview of all changes</b></a>
 

--- a/resources/scss/ceres/common/_common.scss
+++ b/resources/scss/ceres/common/_common.scss
@@ -1,5 +1,4 @@
-div#page-body,
-div.footer {
+div#page-body {
     overflow-x: hidden;
 }
 

--- a/resources/views/PageDesign/Partials/Footer.twig
+++ b/resources/views/PageDesign/Partials/Footer.twig
@@ -9,7 +9,7 @@
 {% set footerContainer = LayoutContainer.show("Ceres::Footer") | trim %}
 {% if footerContainer is empty %}
 
-<div class="footer d-print-none" style="overflow-x: visible !important;">
+<div class="footer d-print-none">
     <div class="btn text-center border mx-auto rounded-lg p-0{% if topButtonPosition == "right" %} back-to-top btn-secondary pt-1{% else %} back-to-top-center{% endif %}">
         <i class="fa fa-chevron-up fa-2x default-float"></i>
     </div>
@@ -131,7 +131,7 @@
     </div>
 </div>
 {% else %}
-    <div class="footer container-max d-print-none">
+    <div class="footer container-max d-print-none" style="overflow-x: visible !important;">
         <div class="row">
             <div class="col clearfix">
                 {{ footerContainer | raw }}

--- a/resources/views/PageDesign/Partials/Footer.twig
+++ b/resources/views/PageDesign/Partials/Footer.twig
@@ -131,7 +131,7 @@
     </div>
 </div>
 {% else %}
-    <div class="footer container-max d-print-none" style="overflow-x: visible !important;">
+    <div class="footer container-max d-print-none">
         <div class="row">
             <div class="col clearfix">
                 {{ footerContainer | raw }}

--- a/resources/views/PageDesign/Partials/Footer.twig
+++ b/resources/views/PageDesign/Partials/Footer.twig
@@ -9,7 +9,7 @@
 {% set footerContainer = LayoutContainer.show("Ceres::Footer") | trim %}
 {% if footerContainer is empty %}
 
-<div class="footer d-print-none">
+<div class="footer d-print-none" style="overflow-x: visible !important;">
     <div class="btn text-center border mx-auto rounded-lg p-0{% if topButtonPosition == "right" %} back-to-top btn-secondary pt-1{% else %} back-to-top-center{% endif %}">
         <i class="fa fa-chevron-up fa-2x default-float"></i>
     </div>


### PR DESCRIPTION
[AB#113104](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/113104)
### All changes meet the following requirements
- [ ] Changelog entry was added
- [ ] Changes have been documented
- [ ] Changes have been tested by the author
- [ ] Changes have been tested by the reviewer
- [ ] Changes to SCSS have been accounted for in plentyShop LTS Modern

@plentymarkets/plentyshop
