### PR TITLE
fix: added check for modern image conversion path

### DIFF
--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -21,6 +21,7 @@
 - Die Einstellung: **Hake die Artikelinformationen an, die du in der Warenkorbvorschau anzeigen möchtest.** im plentyShop Assistenten Schritt **Angezeigte Informationen** hatte keine Auswirkung auf die angezeigten Informationen. Dies wurde behoben.
 - Durch das Fixieren des Headers zum Verbessern der CLS-Werte kam es unter Umständen zu einem ungewünschten Scroll-Verhalten beim Browsen des Shops. Dies wurde behoben.
 - Die Variable "requestedVariationUrl" gibt nun die URL ohne Query-Parameter zurück.
+- Falsches Vorladen des Bildes bei der AVIF-Konvertierung behoben
 
 ### Geändert
 

--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -21,6 +21,7 @@
 - The setting: **Check the boxes of the item information you want to display in the shopping cart preview** in the plentyShop assistant step **Displayed information** had no effect on the information displayed. This has been fixed.
 - Fixing the header to improve CLS values sometimes caused undesired scroll behaviour when browing the shop. This has been fixed.
 - The variable "requestedVariationUrl" now returns the URL without query parameters.
+- Fixed wrong image preload on avif conversion.
 
 ### Changed
 

--- a/resources/views/Widgets/Common/ImageBoxWidget.twig
+++ b/resources/views/Widgets/Common/ImageBoxWidget.twig
@@ -102,7 +102,7 @@
             {{ Twig.endif() }}
 
             {% if preloadImage %}
-                {{ Twig.if("ceresConfig.log.modernImagesConversion") }}
+                {{ Twig.if("ceresConfig.log.modernImagesConversion and imageUrl matches '{item\/images}'") }}
                     {{ Twig.set("preloadAvif", "imageUrl ~ '.avif'")}}
                     {{ Twig.print("add_asset(preloadAvif, 'image')") }}
                  {{ Twig.else() }}

--- a/resources/views/Widgets/Common/ImageCarouselWidget.twig
+++ b/resources/views/Widgets/Common/ImageCarouselWidget.twig
@@ -150,7 +150,7 @@
 
                         {% if preloadImage %}
                             {{ Twig.if("loop.first") }}
-                                {{ Twig.if("ceresConfig.log.modernImagesConversion and slide.type == 'item'") }}
+                                {{ Twig.if("ceresConfig.log.modernImagesConversion and slide.type == 'item' and slide.imageUrl matches '{item\/images}'") }}
                                     {{ Twig.set("preloadAvif", "slide.imageUrl ~ '.avif'")}}
                                     {{ Twig.print("add_asset(preloadAvif, 'image')") }}
                                 {{ Twig.else() }}

--- a/resources/views/Widgets/Common/ItemListWidget.twig
+++ b/resources/views/Widgets/Common/ItemListWidget.twig
@@ -139,7 +139,7 @@
                             {{ Twig.if("counter < maxPreload") }}
                                 {{ Twig.set("itemImage", "item.data.images | itemImages('urlMiddle') | orderByKey('position') | first") }}
 
-                                {{ Twig.if("ceresConfig.log.modernImagesConversion") }}
+                                {{ Twig.if("ceresConfig.log.modernImagesConversion and itemImage.url matches '{item\/images}'") }}
                                     {{ Twig.set("preloadAvif", "itemImage.url ~ '.avif'")}}
                                     {{ Twig.print("add_asset(preloadAvif, 'image')") }}
                                 {{ Twig.else() }}

--- a/resources/views/Widgets/Item/ItemImageWidget.twig
+++ b/resources/views/Widgets/Item/ItemImageWidget.twig
@@ -17,13 +17,13 @@
     {{ Twig.set("itemData", "item.documents[0].data") }}
     {{ Twig.set("itemImage", "itemData.images | itemImages(_imageSize) | orderByKey('position') | first") }}
 
-    {{ Twig.if("ceresConfig.log.modernImagesConversion") }}
+    {{ Twig.if("ceresConfig.log.modernImagesConversion and itemImage.url matches '{item\/images}'") }}
         {{ Twig.set("preloadAvif", "itemImage.url ~ '.avif'")}}
         {{ Twig.print("add_asset(preloadAvif, 'image')") }}
     {{ Twig.else() }}
         {{ Twig.print("add_asset(itemImage.url,'image')") }}
      {{ Twig.endif() }}
-    
+
 {% endif %}
 
 


### PR DESCRIPTION
### All changes meet the following requirements
- [ ] Changelog entry was added
- [ ] Changes have been documented
- [ ] Changes have been tested by the author
- [ ] Changes have been tested by the reviewer
- [ ] Changes to SCSS have been accounted for in plentyShop LTS Modern

@plentymarkets/plentyshop
