### PR TITLE
Improve Modal accessibility

### DIFF
--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -7,6 +7,8 @@
 - Fixed a broken aria reference in the header.
 - Fixed an overlap of the feedback counter with the stars on category page.
 - Fixed alt text for logo not being linked to webspace field.
+- Added aria-labelledby reference to modals for improved accessibility.
+- Changed modal headlines to use HTML headlines instead of normal text for improved accessibility.
 
 ## v5.0.73 (2025-06-02) <a href="https://github.com/plentymarkets/plugin-ceres/compare/5.0.72...5.0.73" target="_blank" rel="noopener"><b>Overview of all changes</b></a>
 

--- a/resources/js/src/app/components/basket/AddItemToBasketOverlay.vue
+++ b/resources/js/src/app/components/basket/AddItemToBasketOverlay.vue
@@ -1,12 +1,12 @@
 <template>
     <div id="add-item-to-basket-overlay">
-        <div class="modal fade">
-            <div class="modal-dialog" role="document">
+        <div class="modal fade" role="dialog" aria-labelledby="modal-title" aria-modal="true">
+            <div class="modal-dialog">
                 <div class="modal-content" v-if="basketItem">
 
                     <!-- MODAL HEADER -->
                     <div class="modal-header">
-                        <div class="modal-title h5">{{ $translate("Ceres::Template.singleItemAdded") }}</div>
+                        <h5 class="modal-title">{{ $translate("Ceres::Template.singleItemAdded") }}</h5>
                         <span class="text-muted ml-auto"><span class="timer"></span>s</span>
                         <button type="button" class="close ml-0 pl-1" data-dismiss="modal" :aria-label="$translate('Ceres::Template.closeIcon')">
                             <span aria-hidden="true">&times;</span>

--- a/resources/js/src/app/components/basket/AddItemToBasketOverlay.vue
+++ b/resources/js/src/app/components/basket/AddItemToBasketOverlay.vue
@@ -6,7 +6,7 @@
 
                     <!-- MODAL HEADER -->
                     <div class="modal-header">
-                        <h5 class="modal-title">{{ $translate("Ceres::Template.singleItemAdded") }}</h5>
+                        <h5 id="modal-title" class="modal-title">{{ $translate("Ceres::Template.singleItemAdded") }}</h5>
                         <span class="text-muted ml-auto"><span class="timer"></span>s</span>
                         <button type="button" class="close ml-0 pl-1" data-dismiss="modal" :aria-label="$translate('Ceres::Template.closeIcon')">
                             <span aria-hidden="true">&times;</span>

--- a/resources/js/src/app/components/customer/login/ForgotPassword.vue
+++ b/resources/js/src/app/components/customer/login/ForgotPassword.vue
@@ -4,7 +4,7 @@
 			<div class="modal-dialog">
 				<div class="modal-content">
 					<div class="modal-header">
-						<h3 class="modal-title">{{ $translate("Ceres::Template.loginForgotPassword") }}</h3>
+						<h3 id="modal-title" class="modal-title">{{ $translate("Ceres::Template.loginForgotPassword") }}</h3>
 						<button type="button" class="close" data-dismiss="modal" aria-hidden="true" :aria-label="$translate('Ceres::Template.closeIcon')">&times;</button>
 					</div>
 					<div class="modal-body">

--- a/resources/js/src/app/components/customer/login/ForgotPassword.vue
+++ b/resources/js/src/app/components/customer/login/ForgotPassword.vue
@@ -1,10 +1,10 @@
 <template>
 	<form :id="'reset-pwd-form-' + _uid" method="post" class="reset-pwd-container login-pwd-reset">
-		<div class="modal fade" id="resetPwd" ref="pwdModal" tabindex="-1" role="dialog">
+		<div class="modal fade" id="resetPwd" ref="pwdModal" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-modal="true">
 			<div class="modal-dialog">
 				<div class="modal-content">
 					<div class="modal-header">
-						<div class="modal-title h3">{{ $translate("Ceres::Template.loginForgotPassword") }}</div>
+						<h3 class="modal-title">{{ $translate("Ceres::Template.loginForgotPassword") }}</h3>
 						<button type="button" class="close" data-dismiss="modal" aria-hidden="true" :aria-label="$translate('Ceres::Template.closeIcon')">&times;</button>
 					</div>
 					<div class="modal-body">

--- a/resources/js/src/app/components/customer/login/LoginView.vue
+++ b/resources/js/src/app/components/customer/login/LoginView.vue
@@ -33,11 +33,11 @@
             </div>
         </div>
 
-        <div class="modal fade" ref="guestModal" tabindex="-1" role="dialog">
+        <div class="modal fade" ref="guestModal" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-modal="true">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <div class="modal-title h3">{{ $translate("Ceres::Template.loginOrderAsGuest") }}</div>
+                        <h3 class="modal-title">{{ $translate("Ceres::Template.loginOrderAsGuest") }}</h3>
                         <button type="button" class="close" data-testing="guest-login-modal" data-dismiss="modal" aria-hidden="true" :aria-label="$translate('Ceres::Template.closeIcon')">&times;</button>
                     </div>
                     <div class="modal-body">

--- a/resources/js/src/app/components/customer/login/LoginView.vue
+++ b/resources/js/src/app/components/customer/login/LoginView.vue
@@ -37,7 +37,7 @@
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <h3 class="modal-title">{{ $translate("Ceres::Template.loginOrderAsGuest") }}</h3>
+                        <h3 id="modal-title" class="modal-title">{{ $translate("Ceres::Template.loginOrderAsGuest") }}</h3>
                         <button type="button" class="close" data-testing="guest-login-modal" data-dismiss="modal" aria-hidden="true" :aria-label="$translate('Ceres::Template.closeIcon')">&times;</button>
                     </div>
                     <div class="modal-body">

--- a/resources/js/src/app/components/myAccount/EditCouponOverlay.vue
+++ b/resources/js/src/app/components/myAccount/EditCouponOverlay.vue
@@ -36,7 +36,7 @@
                         
                         <!-- MODAL HEADER -->
                         <div class="modal-header">
-                            <h4 class="modal-title">{{ $translate("Ceres::Template.couponEdit") }}</h4>
+                            <h4 id="modal-title" class="modal-title">{{ $translate("Ceres::Template.couponEdit") }}</h4>
                             <button type="button" class="close" data-dismiss="modal" :aria-label="$translate('Ceres::Template.closeIcon')" @click="closeEditModal()">
                                 <span aria-hidden="true">&times;</span>
                             </button>
@@ -133,7 +133,7 @@
                     
                     <!-- MODAL HEADER -->
                     <div class="modal-header">
-                        <h4 class="modal-title">{{ $translate("Ceres::Template.couponFinalize") }}</h4>
+                        <h4 id="modal-title" class="modal-title">{{ $translate("Ceres::Template.couponFinalize") }}</h4>
                         <button type="button" class="close" data-dismiss="modal" :aria-label="$translate('Ceres::Template.closeIcon')" @click="closeConfirmModal()">
                             <span aria-hidden="true">&times;</span>
                         </button>

--- a/resources/js/src/app/components/myAccount/EditCouponOverlay.vue
+++ b/resources/js/src/app/components/myAccount/EditCouponOverlay.vue
@@ -30,13 +30,13 @@
             </div>
         </div>
         <form method="post" @submit.prevent="submit()">
-            <div :id="'edit-coupon-overlay-' + _uid" class="modal fade" tabindex="-1" role="dialog" ref="editCouponOverlay">
-                <div class="modal-dialog modal-lg mx-auto modal-dialog-scrollable" role="document">
+            <div :id="'edit-coupon-overlay-' + _uid" class="modal fade" tabindex="-1" role="dialog" ref="editCouponOverlay" aria-labelledby="modal-title" aria-modal="true">
+                <div class="modal-dialog modal-lg mx-auto modal-dialog-scrollable">
                     <div class="modal-content">
                         
                         <!-- MODAL HEADER -->
                         <div class="modal-header">
-                            <div class="modal-title h4">{{ $translate("Ceres::Template.couponEdit") }}</div>
+                            <h4 class="modal-title">{{ $translate("Ceres::Template.couponEdit") }}</h4>
                             <button type="button" class="close" data-dismiss="modal" :aria-label="$translate('Ceres::Template.closeIcon')" @click="closeEditModal()">
                                 <span aria-hidden="true">&times;</span>
                             </button>
@@ -127,13 +127,13 @@
             </div>
         </form>
 
-        <div id="confirm-finalization-overlay" class="modal fade" tabindex="-1" role="dialog" ref="confirmFinalizationOverlay">
-            <div class="modal-dialog" role="document">
+        <div id="confirm-finalization-overlay" class="modal fade" tabindex="-1" role="dialog" ref="confirmFinalizationOverlay" aria-labelledby="modal-title" aria-modal="true">
+            <div class="modal-dialog">
                 <div class="modal-content">
                     
                     <!-- MODAL HEADER -->
                     <div class="modal-header">
-                        <div class="modal-title h4">{{ $translate("Ceres::Template.couponFinalize") }}</div>
+                        <h4 class="modal-title">{{ $translate("Ceres::Template.couponFinalize") }}</h4>
                         <button type="button" class="close" data-dismiss="modal" :aria-label="$translate('Ceres::Template.closeIcon')" @click="closeConfirmModal()">
                             <span aria-hidden="true">&times;</span>
                         </button>

--- a/resources/js/src/app/components/orderReturn/OrderReturn.vue
+++ b/resources/js/src/app/components/orderReturn/OrderReturn.vue
@@ -20,7 +20,7 @@
             </button>
         </div>
 
-        <div class="modal fade" ref="orderReturnConfirmation" tabindex="-1" role="dialog">
+        <div class="modal fade" ref="orderReturnConfirmation" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-modal="true">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">

--- a/resources/js/src/app/components/orderReturn/OrderReturn.vue
+++ b/resources/js/src/app/components/orderReturn/OrderReturn.vue
@@ -24,7 +24,7 @@
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <h3 class="modal-title">{{ $translate("Ceres::Template.returnSendBack") }}</h3>
+                        <h3 id="modal-title" class="modal-title">{{ $translate("Ceres::Template.returnSendBack") }}</h3>
                         <button type="button" class="close" data-dismiss="modal" aria-hidden="true" :aria-label="$translate('Ceres::Template.closeIcon')">&times;</button>
                     </div>
                     <div class="modal-body">

--- a/resources/views/Customer/Components/AddressSelect/AddressSelect.twig
+++ b/resources/views/Customer/Components/AddressSelect/AddressSelect.twig
@@ -166,7 +166,7 @@
                 <div class="modal-dialog">
                     <div class="modal-content">
                         <div class="modal-header">
-                            <h4 class="modal-title">${headline}</h4>
+                            <h4 id="modal-title" class="modal-title">${headline}</h4>
                             <button type="button" class="close" @click="closeAddressModal" aria-label="{{ trans("Ceres::Template.closeIcon") }}">
                                 <span aria-hidden="true">&times;</span>
                             </button>
@@ -195,7 +195,7 @@
                 <div class="modal-dialog" role="document">
                     <div class="modal-content">
                         <div class="modal-header">
-                            <h4 class="modal-title">${headline}</h4>
+                            <h4 id="modal-title" class="modal-title">${headline}</h4>
                             <button type="button" class="close" @click="closeDeleteModal" aria-label="{{ trans("Ceres::Template.closeIcon") }}">
                                 <span aria-hidden="true">&times;</span>
                             </button>

--- a/resources/views/Customer/Components/AddressSelect/AddressSelect.twig
+++ b/resources/views/Customer/Components/AddressSelect/AddressSelect.twig
@@ -162,8 +162,8 @@
         </div>
 
         <div ref="addressModal">
-            <div class="modal fade" tabindex="-1" role="dialog">
-                <div class="modal-dialog" role="document">
+            <div class="modal fade" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-modal="true">
+                <div class="modal-dialog">
                     <div class="modal-content">
                         <div class="modal-header">
                             <h4 class="modal-title">${headline}</h4>
@@ -191,7 +191,7 @@
         </div>
 
         <div ref="deleteModal" {{ set_testing_attr(":data-testing", "\"addressTypePrefix + 'address-select-remove-modal'\"") | raw }}>
-            <div class="modal fade" tabindex="-1" role="dialog">
+            <div class="modal fade" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-modal="true">
                 <div class="modal-dialog" role="document">
                     <div class="modal-content">
                         <div class="modal-header">

--- a/resources/views/MyAccount/Components/AccountSettings.twig
+++ b/resources/views/MyAccount/Components/AccountSettings.twig
@@ -28,8 +28,8 @@
 
         {% if "change-mail" in enabledRoutes or "all" in enabledRoutes %}
             <div ref="accountEmailModal">
-                <div class="modal fade">
-                    <div class="modal-dialog" role="document">
+                <div class="modal fade" role="dialog" aria-labelledby="modal-title" aria-modal="true">
+                    <div class="modal-dialog">
                         <form class="modal-content" method="post" @submit.prevent>
                             <div class="modal-header">
                                 <h4 class="modal-title">{{ trans("Ceres::Template.myAccountChangeEmail") }}</h4>
@@ -72,8 +72,8 @@
         {% endif %}
 
         <div ref="accountPasswordModal">
-            <div class="modal fade">
-                <div class="modal-dialog" role="document">
+            <div class="modal fade" role="dialog" aria-labelledby="modal-title" aria-modal="true">
+                <div class="modal-dialog">
                     <form class="modal-content" method="post" @submit.prevent>
                         <div class="modal-header">
                             <h4 class="modal-title">{{ trans("Ceres::Template.myAccountChangePassword") }}</h4>

--- a/resources/views/MyAccount/Components/AccountSettings.twig
+++ b/resources/views/MyAccount/Components/AccountSettings.twig
@@ -32,7 +32,7 @@
                     <div class="modal-dialog">
                         <form class="modal-content" method="post" @submit.prevent>
                             <div class="modal-header">
-                                <h4 class="modal-title">{{ trans("Ceres::Template.myAccountChangeEmail") }}</h4>
+                                <h4 id="modal-title" class="modal-title">{{ trans("Ceres::Template.myAccountChangeEmail") }}</h4>
                                 <button type="button" class="close" data-dismiss="modal" aria-label="{{ trans("Ceres::Template.closeIcon") }}" @click="clearFields">
                                     <span aria-hidden="true">&times;</span>
                                 </button>
@@ -76,7 +76,7 @@
                 <div class="modal-dialog">
                     <form class="modal-content" method="post" @submit.prevent>
                         <div class="modal-header">
-                            <h4 class="modal-title">{{ trans("Ceres::Template.myAccountChangePassword") }}</h4>
+                            <h4 id="modal-title" class="modal-title">{{ trans("Ceres::Template.myAccountChangePassword") }}</h4>
                             <button type="button" class="close" data-dismiss="modal" aria-label="{{ trans("Ceres::Template.closeIcon") }}" @click="clearFields">
                                 <span aria-hidden="true">&times;</span>
                             </button>

--- a/resources/views/MyAccount/Components/BankDataSelect.twig
+++ b/resources/views/MyAccount/Components/BankDataSelect.twig
@@ -71,8 +71,8 @@
         </div>
 
         <div ref="bankInfoModal">
-            <div class="modal fade" tabindex="-1" role="dialog">
-                <div class="modal-dialog" role="document">
+            <div class="modal fade" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-modal="true">
+                <div class="modal-dialog">
                     <div class="modal-content">
                         <div class="modal-header">
                             <h4 class="modal-title">${headline}</h4>
@@ -131,8 +131,8 @@
         </div>
 
         <div ref="bankDeleteModal">
-            <div class="modal fade" tabindex="-1" role="dialog">
-                <div class="modal-dialog" role="document">
+            <div class="modal fade" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-modal="true">
+                <div class="modal-dialog">
                     <div class="modal-content">
                         <div class="modal-header">
                             <h4 class="modal-title">{{ trans("Ceres::Template.myAccountBankDeleteTitle") }}</h4>

--- a/resources/views/MyAccount/Components/BankDataSelect.twig
+++ b/resources/views/MyAccount/Components/BankDataSelect.twig
@@ -75,7 +75,7 @@
                 <div class="modal-dialog">
                     <div class="modal-content">
                         <div class="modal-header">
-                            <h4 class="modal-title">${headline}</h4>
+                            <h4 id="modal-title" class="modal-title">${headline}</h4>
                             <button type="button" class="close" data-dismiss="modal" aria-label="{{ trans("Ceres::Template.closeIcon") }}">
                                 <span aria-hidden="true">&times;</span>
                             </button>
@@ -135,7 +135,7 @@
                 <div class="modal-dialog">
                     <div class="modal-content">
                         <div class="modal-header">
-                            <h4 class="modal-title">{{ trans("Ceres::Template.myAccountBankDeleteTitle") }}</h4>
+                            <h4 id="modal-title" class="modal-title">{{ trans("Ceres::Template.myAccountBankDeleteTitle") }}</h4>
                             <button type="button" class="close" @click="closeDeleteModal" aria-label="{{ trans("Ceres::Template.closeIcon") }}">
                                 <span aria-hidden="true">&times;</span>
                             </button>

--- a/resources/views/MyAccount/Components/ChangePaymentMethod.twig
+++ b/resources/views/MyAccount/Components/ChangePaymentMethod.twig
@@ -42,7 +42,7 @@
                 <div class="modal-dialog" role="dialog" aria-labelledby="modal-title" aria-modal="true">
                     <div class="modal-content">
                         <div class="modal-header">
-                            <h4 class="modal-title">{{ trans("Ceres::Template.orderHistoryChooseNewPayment") }}</h4>
+                            <h4 id="modal-title" class="modal-title">{{ trans("Ceres::Template.orderHistoryChooseNewPayment") }}</h4>
                             <button type="button" class="close" data-dismiss="modal" aria-label="{{ trans("Ceres::Template.closeIcon") }}" @click="closeModal()">
                                 <span aria-hidden="true">&times;</span>
                             </button>

--- a/resources/views/MyAccount/Components/ChangePaymentMethod.twig
+++ b/resources/views/MyAccount/Components/ChangePaymentMethod.twig
@@ -39,7 +39,7 @@
         <!-- CHANGE_PAYMENT_MODAL -->
         <div ref="changePaymentModal">
             <div class="modal fade" data-backdrop="static">
-                <div class="modal-dialog" role="dialog">
+                <div class="modal-dialog" role="dialog" aria-labelledby="modal-title" aria-modal="true">
                     <div class="modal-content">
                         <div class="modal-header">
                             <h4 class="modal-title">{{ trans("Ceres::Template.orderHistoryChooseNewPayment") }}</h4>

--- a/resources/views/MyAccount/Components/OrderHistory.twig
+++ b/resources/views/MyAccount/Components/OrderHistory.twig
@@ -127,7 +127,7 @@
                 <div class="modal-dialog modal-lg">
                     <div class="modal-content">
                         <div class="modal-header">
-                            <h3 class="modal-title">{{ trans("Ceres::Template.orderHistoryOrderDetails") }}</h3>
+                            <h3 id="modal-title" class="modal-title">{{ trans("Ceres::Template.orderHistoryOrderDetails") }}</h3>
                             <button type="button" class="close" data-dismiss="modal" aria-hidden="true" aria-label="{{ trans("Ceres::Template.closeIcon") }}">&times;</button>
                         </div>
                         <div class="modal-body" style="min-height:350px">

--- a/resources/views/MyAccount/Components/OrderHistory.twig
+++ b/resources/views/MyAccount/Components/OrderHistory.twig
@@ -123,7 +123,7 @@
             </div>
 
             <!-- ORDER DETAILS MODAL -->
-            <div class="modal fade" ref="orderDetails" v-if="currentOrder" tabindex="-1" role="dialog">
+            <div class="modal fade" ref="orderDetails" v-if="currentOrder" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-modal="true">
                 <div class="modal-dialog modal-lg">
                     <div class="modal-content">
                         <div class="modal-header">

--- a/resources/views/PageDesign/PageDesign.twig
+++ b/resources/views/PageDesign/PageDesign.twig
@@ -75,11 +75,11 @@
 
     <!-- LOGIN MODAL -->
     <div id="login-modal-wrapper">
-        <div class="modal fade login-modal" id="login" tabindex="-1" role="dialog">
+        <div class="modal fade login-modal" id="login" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-modal="true">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <div class="modal-title h3">{{ trans("Ceres::Template.login") }}</div>
+                        <h3 class="modal-title">{{ trans("Ceres::Template.login") }}</h3>
                         <button type="button" class="close" data-dismiss="modal" aria-label="{{ trans("Ceres::Template.closeIcon") }}">&times;</button>
                     </div>
                     <lazy-load component="login-modal">
@@ -97,15 +97,14 @@
 
     <!-- REGISTRATION MODAL -->
     <div id="simple-registration-modal-wrapper">
-        <div class="modal fade" id="registration" tabindex="-1" role="dialog">
+        <div class="modal fade" id="registration" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-modal="true">
             <div class="modal-dialog">
                 <lazy-load component="register-modal">
                     <div class="modal-content">
                         <div class="modal-header">
-                            <div class="modal-title h3">
+                            <h3 id="modal-title" class="modal-title">
                                 {{ trans("Ceres::Template.regCreateAccount") }}
-
-                            </div>
+                            </h3>
 
                             <popper v-cloak class="ml-auto">
                                 <template #handle>
@@ -168,11 +167,11 @@
     <!-- SHIPPINGCOSTS MODAL -->
     {% if ceresConfig.global.shippingCostsCategoryId > 0 %}
         <div id="shippingscosts-modal-wrapper">
-            <div class="modal fade" id="shippingscosts" tabindex="-1" role="dialog">
+            <div class="modal fade" id="shippingscosts" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-modal="true">
                 <div class="modal-dialog">
                     <div class="modal-content">
                         <div class="modal-header">
-                            <div class="modal-title h3">{{ trans('Ceres::Template.shippingInfoCosts') }}</div>
+                            <h3 class="modal-title">{{ trans('Ceres::Template.shippingInfoCosts') }}</h3>
                             <button type="button" class="close" data-dismiss="modal" aria-hidden="true" aria-label="{{ trans("Ceres::Template.closeIcon") }}">&times;</button>
                         </div>
                         <div class="modal-body">

--- a/resources/views/PageDesign/PageDesign.twig
+++ b/resources/views/PageDesign/PageDesign.twig
@@ -79,7 +79,7 @@
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <h3 class="modal-title">{{ trans("Ceres::Template.login") }}</h3>
+                        <h3 id="modal-title" class="modal-title">{{ trans("Ceres::Template.login") }}</h3>
                         <button type="button" class="close" data-dismiss="modal" aria-label="{{ trans("Ceres::Template.closeIcon") }}">&times;</button>
                     </div>
                     <lazy-load component="login-modal">
@@ -171,7 +171,7 @@
                 <div class="modal-dialog">
                     <div class="modal-content">
                         <div class="modal-header">
-                            <h3 class="modal-title">{{ trans('Ceres::Template.shippingInfoCosts') }}</h3>
+                            <h3 id="modal-title" class="modal-title">{{ trans('Ceres::Template.shippingInfoCosts') }}</h3>
                             <button type="button" class="close" data-dismiss="modal" aria-hidden="true" aria-label="{{ trans("Ceres::Template.closeIcon") }}">&times;</button>
                         </div>
                         <div class="modal-body">


### PR DESCRIPTION
- Changed modal headlines to use HTML headlines instead of normal text for improved accessibility.

### All changes meet the following requirements
- [x] Changelog entry was added
- [ ] Changes have been documented
- [ ] Changes have been tested by the author
- [ ] Changes have been tested by the reviewer
- [ ] Changes to SCSS have been accounted for in plentyShop LTS Modern

@plentymarkets/plentyshop
