### PR TITLE
Fix/missing aria label on contact form honey pot

### DIFF
--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -2,6 +2,9 @@
 
 ## v5.0.74 (2025-xx-xx) <a href="https://github.com/plentymarkets/plugin-ceres/compare/5.0.73...5.0.74" target="_blank" rel="noopener"><b>Overview of all changes</b></a>
 
+### Added
+- Aria label to honey input from contact.
+
 ### Changed
 
 - Aria label to `a` tag from the category image carousel.

--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -3,7 +3,8 @@
 ## v5.0.74 (2025-xx-xx) <a href="https://github.com/plentymarkets/plugin-ceres/compare/5.0.73...5.0.74" target="_blank" rel="noopener"><b>Overview of all changes</b></a>
 
 ### Added
-- Aria label to honey input from contact.
+
+- Aria label to honey input from contact
 
 ### Changed
 

--- a/resources/views/Customer/Contact.twig
+++ b/resources/views/Customer/Contact.twig
@@ -137,7 +137,14 @@
                     {% endif %}
 
                     <div class="col-12 col-md-3 offset-md-9">
-                    <input class="honey" type="text" name="username" autocomplete="new-password" tabindex="-1">
+                    <input
+                        class="honey"
+                        type="text"
+                        name="username"
+                        autocomplete="new-password"
+                        aria-hidden="true"
+                        aria-label="{{ trans("Ceres::Template.contact") }}"
+                        tabindex="-1">
                         <button type="submit" class="btn-send-contact-form btn btn-primary btn-block">
                             <i class="fa fa-paper-plane-o" aria-hidden="true"></i>
                             {{ trans("Ceres::Template.contactSend") }}


### PR DESCRIPTION
[AB#164374](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/164374)
### All changes meet the following requirements
- [ ] Changelog entry was added
- [ ] Changes have been documented
- [ ] Changes have been tested by the author
- [ ] Changes have been tested by the reviewer
- [ ] Changes to SCSS have been accounted for in plentyShop LTS Modern

@plentymarkets/plentyshop
