### PR TITLE
add default translation value for aria-label of go to homepage button…

### DIFF
--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -1,5 +1,11 @@
 # Release Notes für plentyShop LTS
 
+## v5.0.76 (2025-xx-xx) <a href="https://github.com/plentymarkets/plugin-ceres/compare/5.0.75...5.0.76" target="_blank" rel="noopener"><b>Übersicht aller Änderungen</b></a>
+
+### Hinzugefügt
+
+- Der Home-Button in den Breadcrumbs bekommt ein vorausgefülltes `aria-label` um die Barrierefreiheit zu verbessern. Der entsprechende Übersetzungschlüssel ist `headerBreadcrumbHome`
+
 ## v5.0.75 (2025-08-13) <a href="https://github.com/plentymarkets/plugin-ceres/compare/5.0.74...5.0.75" target="_blank" rel="noopener"><b>Übersicht aller Änderungen</b></a>
 
 ### Behoben

--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -1,5 +1,11 @@
 # Release Notes for plentyShop LTS
 
+## v5.0.76 (2025-xx-xx) <a href="https://github.com/plentymarkets/plugin-ceres/compare/5.0.75...5.0.76" target="_blank" rel="noopener"><b>Overview of all changes</b></a>
+
+### Added
+
+- The home button in the breadcrumbs gets a prefilled `aria-label` to improve accessibility. The corresponding translation key is `headerBreadcrumbHome`.
+
 ## v5.0.75 (2025-08-13) <a href="https://github.com/plentymarkets/plugin-ceres/compare/5.0.74...5.0.75" target="_blank" rel="noopener"><b>Overview of all changes</b></a>
 
 ### Fixed

--- a/resources/lang/de/Template.properties
+++ b/resources/lang/de/Template.properties
@@ -348,7 +348,7 @@ footerStoreFeature3 = "100 Tage Rückgaberecht"
 ; footer - Footer
 ; header - Header
 headerBg = "Bulgarisch"
-headerBreadcrumbHome = ""
+headerBreadcrumbHome = "Zur Startseite gehen"
 headerChangeDeliveryCountry = "Bitte ändern Sie Ihre Adresse, um das Lieferland zu wechseln."
 headerCn = "Chinesisch"
 headerCompanyName = "plentyShop LTS"

--- a/resources/lang/en/Template.properties
+++ b/resources/lang/en/Template.properties
@@ -348,7 +348,7 @@ footerStoreFeature3 = "100-day return policy"
 ; footer - Footer
 ; header - Header
 headerBg = "Bulgarian"
-headerBreadcrumbHome = ""
+headerBreadcrumbHome = "Go to homepage"
 headerChangeDeliveryCountry = "Please change your address in order to change the country of delivery."
 headerCn = "Chinese"
 headerCompanyName = "plentyShop LTS"

--- a/resources/lang/fr/Template.properties
+++ b/resources/lang/fr/Template.properties
@@ -338,7 +338,7 @@ footerStoreFeature3 = "Droit de retour de 100 jours"
 ; footer - Footer
 ; header - Header
 headerBg = "Bulgare"
-headerBreadcrumbHome = ""
+headerBreadcrumbHome = "Aller à la page d’accueil"
 headerChangeDeliveryCountry = "Veuillez modifier votre adresse pour changer le pays fournisseur."
 headerCn = "Chinois"
 headerCompanyName = "Boutique en ligne plentyShop LTS"

--- a/resources/lang/nl/Template.properties
+++ b/resources/lang/nl/Template.properties
@@ -338,7 +338,7 @@ footerStoreFeature3 = "100 dagen retourrecht"
 ; footer - Footer
 ; header - Header
 headerBg = "Bulgaars"
-headerBreadcrumbHome = ""
+headerBreadcrumbHome = "Ga naar de startpagina"
 headerChangeDeliveryCountry = "Wijzig uw adres om het land van levering te wisselen."
 headerCn = "Chinees"
 headerCompanyName = "plentyShop LTS"

--- a/resources/lang/pl/Template.properties
+++ b/resources/lang/pl/Template.properties
@@ -338,7 +338,7 @@ footerStoreFeature3 = "100 dni na zwrot"
 ; footer - Footer
 ; header - Header
 headerBg = "Bułgarski"
-headerBreadcrumbHome = ""
+headerBreadcrumbHome = "Przejdź do strony głównej"
 headerChangeDeliveryCountry = "Zmień adres, aby zmienić kraj dostawy."
 headerCn = "Chiński"
 headerCompanyName = "Sklep internetowy plentyShop LTS"


### PR DESCRIPTION
… in breadcrumb

### All changes meet the following requirements
- [ ] Changelog entry was added
- [ ] Changes have been documented
- [ ] Changes have been tested by the author
- [ ] Changes have been tested by the reviewer
- [ ] Changes to SCSS have been accounted for in plentyShop LTS Modern

@plentymarkets/plentyshop
