### PR TITLE
fix: missing legal required hint at address modal

### DIFF
--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -1,5 +1,11 @@
 # Release Notes für plentyShop LTS
 
+## v5.0.79 (2025-xx-xx) <a href="https://github.com/plentymarkets/plugin-ceres/compare/5.0.78...5.0.79" target="_blank" rel="noopener"><b>Übersicht aller Änderungen</b></a>
+
+### Fixed
+
+- Fehlender Hinweis für erforderliche Adressfelder im Checkout.
+
 ## v5.0.78 (2025-10-17) <a href="https://github.com/plentymarkets/plugin-ceres/compare/5.0.77...5.0.78" target="_blank" rel="noopener"><b>Übersicht aller Änderungen</b></a>
 
 ### TODO

--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -1,5 +1,11 @@
 # Release Notes for plentyShop LTS
 
+## v5.0.79 (2025-xx-xx) <a href="https://github.com/plentymarkets/plugin-ceres/compare/5.0.78...5.0.79" target="_blank" rel="noopener"><b>Overview of all changes</b></a>
+
+### Fixed
+
+- Missing asterix hint for required address input fields in checkout.
+
 ## v5.0.78 (2025-10-17) <a href="https://github.com/plentymarkets/plugin-ceres/compare/5.0.77...5.0.78" target="_blank" rel="noopener"><b>Overview of all changes</b></a>
 
 ### TODO

--- a/resources/lang/de/Template.properties
+++ b/resources/lang/de/Template.properties
@@ -60,6 +60,7 @@ addressTitle = "Titel"
 addressToPickupStation = "An Packstation/Postfiliale senden"
 addressVatNumber = "USt.-Nr."
 addressZip = "PLZ"
+addressRequiredFieldHint = "* hierbei handelt es sich um ein Pflichtfeld."
 ; address - Addressen
 ; alreadyPaid - Bezahlt
 alreadyPaidPaymentMethodName = "Bereits bezahlt"

--- a/resources/lang/en/Template.properties
+++ b/resources/lang/en/Template.properties
@@ -60,6 +60,7 @@ addressTitle = "Title"
 addressToPickupStation = "Deliver to Packstation/post office"
 addressVatNumber = "VAT number"
 addressZip = "Postcode"
+addressRequiredFieldHint = "* this is a required field."
 ; address - Address
 ; alreadyPaid - Already paid
 alreadyPaidPaymentMethodName = "Already paid"

--- a/resources/lang/fr/Template.properties
+++ b/resources/lang/fr/Template.properties
@@ -57,6 +57,7 @@ addressTitle = "Titre"
 addressToPickupStation = "Envoyer à la station de conditionnement / au bureau de poste"
 addressVatNumber = "N° de TVA"
 addressZip = "CP"
+addressRequiredFieldHint = "* Ce champ est obligatoire."
 ; address - Addressen
 ; basket - Warenkorb
 basket = "Panier de commandes"

--- a/resources/lang/nl/Template.properties
+++ b/resources/lang/nl/Template.properties
@@ -57,6 +57,7 @@ addressTitle = "Titel"
 addressToPickupStation = "Aan pakstation/postfiliaal verzenden"
 addressVatNumber = "Btw-nr."
 addressZip = "Postcode"
+addressRequiredFieldHint = "* Dit is een verplicht veld."
 ; address - Addressen
 ; basket - Warenkorb
 basket = "Winkelwagen"

--- a/resources/lang/pl/Template.properties
+++ b/resources/lang/pl/Template.properties
@@ -57,6 +57,7 @@ addressTitle = "Tytuł"
 addressToPickupStation = "Wyślij do Packstation/urzędu pocztowego"
 addressVatNumber = "NIP UE"
 addressZip = "Kod pocztowy"
+addressRequiredFieldHint = "* Jest to pole obowiązkowe."
 ; address - Addressen
 ; basket - Warenkorb
 basket = "Koszyk"

--- a/resources/views/Customer/Components/AddressSelect/CreateUpdateAddress.twig
+++ b/resources/views/Customer/Components/AddressSelect/CreateUpdateAddress.twig
@@ -23,5 +23,6 @@
             :disabled="waiting">
             {{ trans("Ceres::Template.addressSave") }}
         </button>
+        <div class="mt-2">{{ trans("Ceres::Template.addressRequiredFieldHint") }}</div>
     </form>
 </script>


### PR DESCRIPTION
[AB#180668](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/180668)
<img width="658" height="714" alt="Screenshot 2025-12-08 at 12 33 34" src="https://github.com/user-attachments/assets/80d901bb-fd93-431f-b6f8-22b552874121" />




### All changes meet the following requirements
- [x] Changelog entry was added
- [ ] Changes have been documented
- [x] Changes have been tested by the author
- [ ] Changes have been tested by the reviewer
- [ ] Changes to SCSS have been accounted for in plentyShop LTS Modern

@plentymarkets/plentyshop
